### PR TITLE
feat: implement CreateClinicalRecordUseCase with attachments

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/AttachmentDto.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/AttachmentDto.java
@@ -1,0 +1,14 @@
+package com.qiromanager.qiromanager_backend.api.clinicalrecords;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AttachmentDto {
+    private Long id;
+    private String url;
+    private String originalFilename;
+    private String mimeType;
+    private Long size;
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/ClinicalRecordResponse.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/ClinicalRecordResponse.java
@@ -1,0 +1,20 @@
+package com.qiromanager.qiromanager_backend.api.clinicalrecords;
+
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.RecordType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class ClinicalRecordResponse {
+    private Long id;
+    private Long patientId;
+    private String performedByName;
+    private RecordType type;
+    private String content;
+    private List<AttachmentDto> attachments;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/CreateClinicalRecordRequest.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/CreateClinicalRecordRequest.java
@@ -1,0 +1,16 @@
+package com.qiromanager.qiromanager_backend.api.clinicalrecords;
+
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.RecordType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CreateClinicalRecordRequest {
+
+    @NotNull(message = "Record type is required")
+    private RecordType type;
+
+    @NotBlank(message = "Content cannot be empty")
+    private String content;
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/mappers/ClinicalRecordMapper.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/mappers/ClinicalRecordMapper.java
@@ -1,0 +1,44 @@
+package com.qiromanager.qiromanager_backend.api.mappers;
+
+import com.qiromanager.qiromanager_backend.api.clinicalrecords.AttachmentDto;
+import com.qiromanager.qiromanager_backend.api.clinicalrecords.ClinicalRecordResponse;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.Attachment;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecord;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ClinicalRecordMapper {
+
+    public ClinicalRecordResponse toResponse(ClinicalRecord record) {
+        return ClinicalRecordResponse.builder()
+                .id(record.getId())
+                .patientId(record.getPatient().getId())
+                .performedByName(record.getPerformedBy() != null ?
+                        record.getPerformedBy().getFullName() :
+                        "Unknown")
+                .type(record.getType())
+                .content(record.getContent())
+                .createdAt(record.getCreatedAt())
+                .attachments(toAttachmentDtoList(record))
+                .build();
+    }
+
+    private List<AttachmentDto> toAttachmentDtoList(ClinicalRecord record) {
+        return record.getAttachments().stream()
+                .map(this::toAttachmentDto)
+                .collect(Collectors.toList());
+    }
+
+    private AttachmentDto toAttachmentDto(Attachment attachment) {
+        return AttachmentDto.builder()
+                .id(attachment.getId())
+                .url(attachment.getUrl())
+                .originalFilename(attachment.getOriginalFilename())
+                .mimeType(attachment.getMimeType())
+                .size(attachment.getSize())
+                .build();
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/CreateClinicalRecordUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/CreateClinicalRecordUseCase.java
@@ -1,0 +1,62 @@
+package com.qiromanager.qiromanager_backend.application.clinicalrecords;
+
+import com.qiromanager.qiromanager_backend.api.clinicalrecords.ClinicalRecordResponse;
+import com.qiromanager.qiromanager_backend.api.clinicalrecords.CreateClinicalRecordRequest;
+import com.qiromanager.qiromanager_backend.api.mappers.ClinicalRecordMapper;
+import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecord;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecordRepository;
+import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
+import com.qiromanager.qiromanager_backend.domain.storage.StoragePort;
+import com.qiromanager.qiromanager_backend.domain.storage.StoredFile;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class CreateClinicalRecordUseCase {
+
+    private final ClinicalRecordRepository clinicalRecordRepository;
+    private final PatientRepository patientRepository;
+    private final AuthenticatedUserService authenticatedUserService;
+    private final StoragePort storagePort;
+    private final ClinicalRecordMapper mapper;
+
+    @Transactional
+    public ClinicalRecordResponse execute(Long patientId, CreateClinicalRecordRequest request, MultipartFile file) {
+        User currentUser = authenticatedUserService.getCurrentUser();
+
+        Patient patient = patientRepository.findById(patientId)
+                .orElseThrow(() -> new PatientNotFoundException(patientId));
+
+        authenticatedUserService.assertCanAccessPatient(currentUser, patient);
+
+        ClinicalRecord record = ClinicalRecord.create(
+                patient,
+                currentUser,
+                request.getType(),
+                request.getContent()
+        );
+
+        if (file != null && !file.isEmpty()) {
+            StoredFile storedFile = storagePort.upload(file);
+
+            record.addAttachment(
+                    storedFile.getUrl(),
+                    storedFile.getPublicId(),
+                    file.getOriginalFilename(),
+                    file.getContentType(),
+                    file.getSize()
+            );
+        }
+
+        ClinicalRecord savedRecord = clinicalRecordRepository.save(record);
+
+        return mapper.toResponse(savedRecord);
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/CreateClinicalRecordUseCaseIT.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/CreateClinicalRecordUseCaseIT.java
@@ -1,0 +1,133 @@
+package com.qiromanager.qiromanager_backend.application.clinicalrecords;
+
+import com.qiromanager.qiromanager_backend.api.clinicalrecords.ClinicalRecordResponse;
+import com.qiromanager.qiromanager_backend.api.clinicalrecords.CreateClinicalRecordRequest;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecord;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecordRepository;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.RecordType;
+import com.qiromanager.qiromanager_backend.domain.exceptions.UnauthorizedRoleException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
+import com.qiromanager.qiromanager_backend.domain.storage.StoragePort;
+import com.qiromanager.qiromanager_backend.domain.storage.StoredFile;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class CreateClinicalRecordUseCaseIT {
+
+    @Autowired
+    private CreateClinicalRecordUseCase createClinicalRecordUseCase;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PatientRepository patientRepository;
+
+    @Autowired
+    private ClinicalRecordRepository clinicalRecordRepository;
+
+    @MockitoBean
+    private StoragePort storagePort;
+
+    private User therapist;
+    private Patient patient;
+
+    @BeforeEach
+    void setup() {
+        therapist = User.create("Therapist John", "therapist", "therapist@test.com", "pass", Role.USER);
+        userRepository.save(therapist);
+
+        patient = Patient.create("Sick Patient", LocalDate.now(), "123", "sick@test.com", "Address", "Notes");
+        patientRepository.save(patient);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("therapist", null, Collections.emptyList())
+        );
+    }
+
+    @Test
+    void shouldCreateRecord_WithAttachment_WhenUserIsAssigned() {
+        patient.assignTherapist(therapist);
+        patientRepository.save(patient);
+
+        CreateClinicalRecordRequest request = new CreateClinicalRecordRequest();
+        request.setType(RecordType.EVOLUTION);
+        request.setContent("Patient reports feeling much better.");
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "xray.pdf", "application/pdf", "dummy content".getBytes()
+        );
+
+        when(storagePort.upload(any())).thenReturn(
+                StoredFile.builder()
+                        .url("http://cloudinary.fake/xray.pdf")
+                        .publicId("folder/xray_123")
+                        .build()
+        );
+
+        ClinicalRecordResponse response = createClinicalRecordUseCase.execute(patient.getId(), request, file);
+
+        assertThat(response.getId()).isNotNull();
+        assertThat(response.getContent()).isEqualTo("Patient reports feeling much better.");
+        assertThat(response.getAttachments()).hasSize(1);
+        assertThat(response.getAttachments().get(0).getUrl()).isEqualTo("http://cloudinary.fake/xray.pdf");
+
+        ClinicalRecord savedRecord = clinicalRecordRepository.findById(response.getId()).orElseThrow();
+        assertThat(savedRecord.getAttachments()).hasSize(1);
+        assertThat(savedRecord.getAttachments().iterator().next().getPublicId()).isEqualTo("folder/xray_123");
+
+        verify(storagePort, times(1)).upload(any());
+    }
+
+    @Test
+    void shouldCreateRecord_WithoutAttachment() {
+        patient.assignTherapist(therapist);
+        patientRepository.save(patient);
+
+        CreateClinicalRecordRequest request = new CreateClinicalRecordRequest();
+        request.setType(RecordType.ANAMNESIS);
+        request.setContent("Initial interview.");
+
+        ClinicalRecordResponse response = createClinicalRecordUseCase.execute(patient.getId(), request, null);
+
+        assertThat(response.getId()).isNotNull();
+        assertThat(response.getAttachments()).isEmpty();
+
+        verify(storagePort, never()).upload(any());
+    }
+
+    @Test
+    void shouldThrowException_WhenUserNotAssigned() {
+        CreateClinicalRecordRequest request = new CreateClinicalRecordRequest();
+        request.setType(RecordType.EVOLUTION);
+        request.setContent("Trying to hack access.");
+
+        assertThatThrownBy(() -> createClinicalRecordUseCase.execute(patient.getId(), request, null))
+                .isInstanceOf(UnauthorizedRoleException.class);
+
+        assertThat(clinicalRecordRepository.findByPatientId(patient.getId())).isEmpty();
+    }
+}


### PR DESCRIPTION
- Add DTOs: CreateClinicalRecordRequest, AttachmentDto, ClinicalRecordResponse
- Add ClinicalRecordMapper for entity-dto conversion
- Add CreateClinicalRecordUseCase with security checks and storage integration
- Add CreateClinicalRecordUseCaseIT integration test using MockitoBean