### PR TITLE
fix: restrict CORS to explicit allowed origins per environment

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.qiromanager.qiromanager_backend.security.config;
 
 import com.qiromanager.qiromanager_backend.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -24,6 +25,9 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthFilter;
+
+    @Value("${app.cors.allowed-origins}")
+    private String allowedOrigins;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -72,7 +76,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOriginPattern("*");
+        config.addAllowedOrigin(allowedOrigins);
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");
         config.setAllowCredentials(true);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,6 +20,9 @@ server:
   port: 8080
 
 app:
+  cors:
+    allowed-origins: http://localhost:3000
+
   jwt:
     secret: ${JWT_SECRET:qiro-manager-temporary-dev-secret-key-must-be-32-bytes}
     expiration-millis: ${JWT_EXPIRATION:3600000}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,7 @@
+app:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}
+
 spring:
   datasource:
     url: jdbc:mysql://PRODUCTION_URL/qiromanager


### PR DESCRIPTION
## Summary

- Replaced `addAllowedOriginPattern("*")` with an explicit `addAllowedOrigin()` using a configurable property
- Resolves the conflict between wildcard origin and `setAllowCredentials(true)`, which browsers reject
- Dev profile defaults to `http://localhost:3000`; prod reads from `CORS_ALLOWED_ORIGINS` environment variable

## Test plan

- [ ] Start backend in dev profile — frontend at `localhost:3000` should connect normally
- [ ] Verify requests from a different origin are rejected with a CORS error
- [ ] Before deploying to prod, set the `CORS_ALLOWED_ORIGINS` env var to the frontend URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)