### PR TITLE
fix: add file upload validation for clinical records

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/api/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/exceptions/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 @Slf4j
@@ -80,6 +81,18 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
         log.warn("Access denied at {}: {}", request.getRequestURI(), ex.getMessage());
         return buildError(HttpStatus.FORBIDDEN, "Access denied", request);
+    }
+
+    @ExceptionHandler(InvalidFileException.class)
+    public ResponseEntity<ApiError> handleInvalidFile(InvalidFileException ex, HttpServletRequest request) {
+        log.warn("Invalid file upload at {}: {}", request.getRequestURI(), ex.getMessage());
+        return buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiError> handleMaxUploadSize(MaxUploadSizeExceededException ex, HttpServletRequest request) {
+        log.warn("File upload too large at {}", request.getRequestURI());
+        return buildError(HttpStatus.BAD_REQUEST, "File size exceeds the maximum allowed limit of 10 MB", request);
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/CreateClinicalRecordUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/CreateClinicalRecordUseCase.java
@@ -6,6 +6,7 @@ import com.qiromanager.qiromanager_backend.api.mappers.ClinicalRecordMapper;
 import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
 import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecord;
 import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecordRepository;
+import com.qiromanager.qiromanager_backend.domain.exceptions.InvalidFileException;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
@@ -18,10 +19,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class CreateClinicalRecordUseCase {
+
+    private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "application/pdf"
+    );
+    private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 
     private final ClinicalRecordRepository clinicalRecordRepository;
     private final PatientRepository patientRepository;
@@ -44,6 +54,7 @@ public class CreateClinicalRecordUseCase {
         );
 
         if (file != null && !file.isEmpty()) {
+            validateFile(file);
             log.info("Uploading attachment for Clinical Record (Patient ID: {})", patientId);
             StoredFile storedFile = storagePort.upload(file);
 
@@ -57,8 +68,22 @@ public class CreateClinicalRecordUseCase {
         }
 
         ClinicalRecord savedRecord = clinicalRecordRepository.save(record);
+
         log.info("Clinical Record created successfully (ID: {})", savedRecord.getId());
 
         return mapper.toResponse(savedRecord);
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.getSize() > MAX_FILE_SIZE_BYTES) {
+            throw new InvalidFileException("File size exceeds the maximum allowed limit of 10 MB");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_MIME_TYPES.contains(contentType)) {
+            throw new InvalidFileException(
+                    "File type not allowed. Accepted types: JPEG, PNG, PDF"
+            );
+        }
     }
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/exceptions/InvalidFileException.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/exceptions/InvalidFileException.java
@@ -1,0 +1,7 @@
+package com.qiromanager.qiromanager_backend.domain.exceptions;
+
+public class InvalidFileException extends RuntimeException {
+    public InvalidFileException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,8 @@ spring:
 
   profiles:
     active: dev
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB


### PR DESCRIPTION
## Summary
- Validate MIME type before uploading to Cloudinary: only JPEG, PNG and PDF are accepted
- Validate file size in the use case (max 10 MB) as a second layer of defense
- Configure `spring.servlet.multipart.max-file-size` globally in `application.yml` so Spring rejects oversized requests before they reach the application layer
- Add `InvalidFileException` and `MaxUploadSizeExceededException` handlers to `GlobalExceptionHandler` for consistent error responses (400 Bad Request)

## Test plan
- [ ] Upload a valid JPEG/PNG/PDF → should succeed
- [ ] Upload a file with a disallowed type (e.g. `.exe`, `.txt`) → should return 400 with descriptive message
- [ ] Upload a file larger than 10 MB → should return 400
- [ ] Upload a clinical record without file → should still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)