### PR TITLE
feat: add pagination to patient list and search endpoints

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/api/common/PageResponse.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/common/PageResponse.java
@@ -1,0 +1,30 @@
+package com.qiromanager.qiromanager_backend.api.common;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponse<T> {
+
+    private final List<T> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean last;
+
+    private PageResponse(Page<T> pageData) {
+        this.content = pageData.getContent();
+        this.page = pageData.getNumber();
+        this.size = pageData.getSize();
+        this.totalElements = pageData.getTotalElements();
+        this.totalPages = pageData.getTotalPages();
+        this.last = pageData.isLast();
+    }
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(page);
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/patients/PatientController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/patients/PatientController.java
@@ -1,14 +1,16 @@
 package com.qiromanager.qiromanager_backend.api.patients;
 
+import com.qiromanager.qiromanager_backend.api.common.PageResponse;
 import com.qiromanager.qiromanager_backend.application.patients.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/patients")
@@ -40,15 +42,18 @@ public class PatientController {
 
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping
-    public ResponseEntity<List<PatientResponse>> getAllPatients(
-            @RequestParam(required = false) Boolean assignedToMe
+    public ResponseEntity<PageResponse<PatientResponse>> getAllPatients(
+            @RequestParam(required = false) Boolean assignedToMe,
+            @PageableDefault(size = 20, sort = "fullName") Pageable pageable
     ) {
-        log.info("Request received: List patients (AssignedToMe filter: {})", assignedToMe);
+        log.info("Request received: List patients (AssignedToMe filter: {}, page: {}, size: {})",
+                assignedToMe, pageable.getPageNumber(), pageable.getPageSize());
 
-        List<PatientResponse> patients = listPatientsUseCase.execute(assignedToMe);
+        Page<PatientResponse> patients = listPatientsUseCase.execute(assignedToMe, pageable);
 
-        log.debug("Returning {} patients", patients.size());
-        return ResponseEntity.ok(patients);
+        log.debug("Returning page {}/{} ({} patients)", pageable.getPageNumber(),
+                patients.getTotalPages(), patients.getNumberOfElements());
+        return ResponseEntity.ok(PageResponse.from(patients));
     }
 
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
@@ -92,13 +97,17 @@ public class PatientController {
 
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping("/search")
-    public ResponseEntity<List<PatientResponse>> searchPatients(@RequestParam String query) {
-        log.info("Request received: Search patients with query: '{}'", query);
+    public ResponseEntity<PageResponse<PatientResponse>> searchPatients(
+            @RequestParam String query,
+            @PageableDefault(size = 20, sort = "fullName") Pageable pageable
+    ) {
+        log.info("Request received: Search patients with query: '{}' (page: {}, size: {})",
+                query, pageable.getPageNumber(), pageable.getPageSize());
 
-        List<PatientResponse> results = searchPatientsUseCase.execute(query);
+        Page<PatientResponse> results = searchPatientsUseCase.execute(query, pageable);
 
-        log.debug("Search found {} matching patients", results.size());
-        return ResponseEntity.ok(results);
+        log.debug("Search found {} matching patients", results.getTotalElements());
+        return ResponseEntity.ok(PageResponse.from(results));
     }
 
     @PreAuthorize("hasAnyRole('USER','ADMIN')")

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/patients/ListPatientsUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/patients/ListPatientsUseCase.java
@@ -3,14 +3,13 @@ package com.qiromanager.qiromanager_backend.application.patients;
 import com.qiromanager.qiromanager_backend.api.mappers.PatientMapper;
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
 import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
-import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
 import com.qiromanager.qiromanager_backend.domain.user.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,22 +19,19 @@ public class ListPatientsUseCase {
     private final AuthenticatedUserService authenticatedUserService;
 
     @Transactional(readOnly = true)
-    public List<PatientResponse> execute(Boolean assignedToMe) {
+    public Page<PatientResponse> execute(Boolean assignedToMe, Pageable pageable) {
 
         User currentUser = authenticatedUserService.getCurrentUser();
-        List<Patient> patients;
 
         boolean shouldFilterByTherapist = !authenticatedUserService.isAdmin(currentUser)
                 || Boolean.TRUE.equals(assignedToMe);
 
         if (shouldFilterByTherapist) {
-            patients = patientRepository.findActiveByTherapistId(currentUser.getId());
+            return patientRepository.findActiveByTherapistId(currentUser.getId(), pageable)
+                    .map(PatientMapper::toResponse);
         } else {
-            patients = patientRepository.findAllActive();
+            return patientRepository.findAllActive(pageable)
+                    .map(PatientMapper::toResponse);
         }
-
-        return patients.stream()
-                .map(PatientMapper::toResponse)
-                .toList();
     }
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/patients/SearchPatientsUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/patients/SearchPatientsUseCase.java
@@ -2,13 +2,12 @@ package com.qiromanager.qiromanager_backend.application.patients;
 
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
 import com.qiromanager.qiromanager_backend.api.patients.TherapistSummary;
-import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,19 +16,16 @@ public class SearchPatientsUseCase {
     private final PatientRepository patientRepository;
 
     @Transactional(readOnly = true)
-    public List<PatientResponse> execute(String query) {
+    public Page<PatientResponse> execute(String query, Pageable pageable) {
 
-        List<Patient> patients = patientRepository.searchByFullName(query);
-
-        return patients.stream()
+        return patientRepository.searchByFullName(query, pageable)
                 .map(patient -> {
-                    List<TherapistSummary> therapistSummaries =
-                            patient.getTherapists().stream()
-                                    .map(t -> TherapistSummary.builder()
-                                            .id(t.getId())
-                                            .fullName(t.getFullName())
-                                            .build())
-                                    .toList();
+                    var therapistSummaries = patient.getTherapists().stream()
+                            .map(t -> TherapistSummary.builder()
+                                    .id(t.getId())
+                                    .fullName(t.getFullName())
+                                    .build())
+                            .toList();
 
                     return PatientResponse.builder()
                             .id(patient.getId())
@@ -44,6 +40,6 @@ public class SearchPatientsUseCase {
                             .updatedAt(patient.getUpdatedAt())
                             .therapists(therapistSummaries)
                             .build();
-                }).toList();
+                });
     }
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/patient/PatientRepository.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/patient/PatientRepository.java
@@ -1,5 +1,8 @@
 package com.qiromanager.qiromanager_backend.domain.patient;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -11,11 +14,17 @@ public interface PatientRepository {
 
     List<Patient> findAllActive();
 
+    Page<Patient> findAllActive(Pageable pageable);
+
     List<Patient> findActiveByTherapistId(Long therapistId);
+
+    Page<Patient> findActiveByTherapistId(Long therapistId, Pageable pageable);
 
     Patient save(Patient patient);
 
     List<Patient> searchByFullName(String query);
+
+    Page<Patient> searchByFullName(String query, Pageable pageable);
 
     long countAll();
 

--- a/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/patient/PatientRepositoryImpl.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/patient/PatientRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.qiromanager.qiromanager_backend.infrastructure.patient;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
 import com.qiromanager.qiromanager_backend.infrastructure.patient.jpa.JpaPatientRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -33,8 +35,18 @@ public class PatientRepositoryImpl implements PatientRepository {
     }
 
     @Override
+    public Page<Patient> findAllActive(Pageable pageable) {
+        return jpaRepository.findAllActive(pageable);
+    }
+
+    @Override
     public List<Patient> findActiveByTherapistId(Long therapistId) {
         return jpaRepository.findActiveByTherapistId(therapistId);
+    }
+
+    @Override
+    public Page<Patient> findActiveByTherapistId(Long therapistId, Pageable pageable) {
+        return jpaRepository.findActiveByTherapistId(therapistId, pageable);
     }
 
     @Override
@@ -45,6 +57,11 @@ public class PatientRepositoryImpl implements PatientRepository {
     @Override
     public List<Patient> searchByFullName(String query) {
         return jpaRepository.searchByFullName(query);
+    }
+
+    @Override
+    public Page<Patient> searchByFullName(String query, Pageable pageable) {
+        return jpaRepository.searchByFullName(query, pageable);
     }
 
     @Override

--- a/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/patient/jpa/JpaPatientRepository.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/patient/jpa/JpaPatientRepository.java
@@ -1,6 +1,8 @@
 package com.qiromanager.qiromanager_backend.infrastructure.patient.jpa;
 
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,11 +14,20 @@ public interface JpaPatientRepository extends JpaRepository<Patient, Long> {
     @Query("SELECT p FROM Patient p WHERE p.active = true")
     List<Patient> findAllActive();
 
+    @Query("SELECT p FROM Patient p WHERE p.active = true")
+    Page<Patient> findAllActive(Pageable pageable);
+
     @Query("SELECT p FROM Patient p WHERE p.active = true AND LOWER(p.fullName) LIKE LOWER(CONCAT('%', :query, '%'))")
     List<Patient> searchByFullName(@Param("query") String query);
 
+    @Query("SELECT p FROM Patient p WHERE p.active = true AND LOWER(p.fullName) LIKE LOWER(CONCAT('%', :query, '%'))")
+    Page<Patient> searchByFullName(@Param("query") String query, Pageable pageable);
+
     @Query("SELECT p FROM Patient p JOIN p.therapists t WHERE p.active = true AND t.id = :therapistId")
     List<Patient> findActiveByTherapistId(@Param("therapistId") Long therapistId);
+
+    @Query("SELECT p FROM Patient p JOIN p.therapists t WHERE p.active = true AND t.id = :therapistId")
+    Page<Patient> findActiveByTherapistId(@Param("therapistId") Long therapistId, Pageable pageable);
 
     long countByActiveTrue();
 


### PR DESCRIPTION
## Summary
- `GET /api/v1/patients` and `GET /api/v1/patients/search` now return paginated results instead of a full list
- New `PageResponse<T>` wrapper DTO with clean fields: `content`, `page`, `size`, `totalElements`, `totalPages`, `last`
- Default: page 0, 20 results per page, sorted by `fullName` ascending
- The database query now uses `LIMIT/OFFSET` — never loads all records into memory

## New response format
```json
{
  "content": [ ...patients... ],
  "page": 0,
  "size": 20,
  "totalElements": 150,
  "totalPages": 8,
  "last": false
}
```

## Query params
| Param | Default | Example |
|-------|---------|---------|
| `page` | 0 | `?page=2` |
| `size` | 20 | `?size=10` |
| `sort` | `fullName` | `?sort=createdAt,desc` |

## ⚠️ Breaking change for frontend
The response format changes from `[...]` to `{ content: [...], ... }`. The frontend must be updated to read `response.content` instead of the raw array.

## Test plan
- [ ] `GET /api/v1/patients` without params → returns page 0 with 20 results
- [ ] `GET /api/v1/patients?page=1&size=5` → returns correct page
- [ ] `GET /api/v1/patients/search?query=garcia&page=0` → paginated search results
- [ ] `totalPages` and `totalElements` are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)