### PR TITLE
fix: delete Cloudinary file if DB save fails to prevent orphaned files

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/CreateClinicalRecordUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/CreateClinicalRecordUseCase.java
@@ -53,25 +53,36 @@ public class CreateClinicalRecordUseCase {
                 request.getContent()
         );
 
-        if (file != null && !file.isEmpty()) {
-            validateFile(file);
-            log.info("Uploading attachment for Clinical Record (Patient ID: {})", patientId);
-            StoredFile storedFile = storagePort.upload(file);
+        StoredFile storedFile = null;
 
-            record.addAttachment(
-                    storedFile.getUrl(),
-                    storedFile.getPublicId(),
-                    file.getOriginalFilename(),
-                    file.getContentType(),
-                    file.getSize()
-            );
+        try {
+            if (file != null && !file.isEmpty()) {
+                validateFile(file);
+                log.info("Uploading attachment for Clinical Record (Patient ID: {})", patientId);
+                storedFile = storagePort.upload(file);
+
+                record.addAttachment(
+                        storedFile.getUrl(),
+                        storedFile.getPublicId(),
+                        file.getOriginalFilename(),
+                        file.getContentType(),
+                        file.getSize()
+                );
+            }
+
+            ClinicalRecord savedRecord = clinicalRecordRepository.save(record);
+
+            log.info("Clinical Record created successfully (ID: {})", savedRecord.getId());
+
+            return mapper.toResponse(savedRecord);
+
+        } catch (Exception e) {
+            if (storedFile != null) {
+                log.warn("DB save failed after Cloudinary upload. Deleting orphaned file: {}", storedFile.getPublicId());
+                storagePort.delete(storedFile.getPublicId());
+            }
+            throw e;
         }
-
-        ClinicalRecord savedRecord = clinicalRecordRepository.save(record);
-
-        log.info("Clinical Record created successfully (ID: {})", savedRecord.getId());
-
-        return mapper.toResponse(savedRecord);
     }
 
     private void validateFile(MultipartFile file) {


### PR DESCRIPTION
## Summary
- Wrapped the upload + DB save flow in a try-catch in `CreateClinicalRecordUseCase`
- If the DB save fails after a successful Cloudinary upload, the uploaded file is now deleted as a compensating action
- Only 1 file modified, no new dependencies

## Motivation
Cloudinary operates outside the database transaction. If `@Transactional` rolls back the DB operation, the already-uploaded file in Cloudinary has no reference and can never be cleaned up automatically — resulting in storage cost and data pollution over time.

## How it works
```
1. Upload file to Cloudinary  → storedFile (url + publicId)
2. Try to save record to DB
   ✅ Success → return response normally
   ❌ Failure → delete file from Cloudinary, re-throw exception
```

## Test plan
- [ ] Creating a clinical record with a valid file works normally
- [ ] If a DB error occurs after upload, the file is deleted from Cloudinary (check logs for warning message)
- [ ] Creating a clinical record without a file is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)