### PR TITLE
test: add unit tests for auth and user use cases

### DIFF
--- a/src/test/java/com/qiromanager/qiromanager_backend/application/auth/LoginUserUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/auth/LoginUserUseCaseTest.java
@@ -1,0 +1,100 @@
+package com.qiromanager.qiromanager_backend.application.auth;
+
+import com.qiromanager.qiromanager_backend.api.auth.AuthResponse;
+import com.qiromanager.qiromanager_backend.api.auth.LoginRequest;
+import com.qiromanager.qiromanager_backend.domain.exceptions.InvalidCredentialsException;
+import com.qiromanager.qiromanager_backend.domain.exceptions.UserInactiveException;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
+import com.qiromanager.qiromanager_backend.security.jwt.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoginUserUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private LoginUserUseCase loginUserUseCase;
+
+    private User activeUser;
+    private LoginRequest request;
+
+    @BeforeEach
+    void setUp() {
+        activeUser = User.create("Jane Doe", "janedoe", "jane@clinic.com", "encodedPass", Role.USER);
+        activeUser.forceId(1L);
+
+        request = new LoginRequest();
+        request.setUsername("janedoe");
+        request.setPassword("rawPassword");
+    }
+
+    @Test
+    void execute_shouldReturnToken_whenCredentialsAreValid() {
+        when(userRepository.findByUsername("janedoe")).thenReturn(Optional.of(activeUser));
+        when(passwordEncoder.matches("rawPassword", "encodedPass")).thenReturn(true);
+        when(jwtUtil.generateToken(activeUser)).thenReturn("jwt-token");
+
+        AuthResponse response = loginUserUseCase.execute(request);
+
+        assertThat(response.getToken()).isEqualTo("jwt-token");
+        assertThat(response.getUsername()).isEqualTo("janedoe");
+        assertThat(response.getRole()).isEqualTo("USER");
+    }
+
+    @Test
+    void execute_shouldThrowInvalidCredentials_whenUserNotFound() {
+        when(userRepository.findByUsername("janedoe")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> loginUserUseCase.execute(request))
+                .isInstanceOf(InvalidCredentialsException.class);
+
+        verify(passwordEncoder, never()).matches(any(), any());
+        verify(jwtUtil, never()).generateToken(any());
+    }
+
+    @Test
+    void execute_shouldThrowInvalidCredentials_whenPasswordIsWrong() {
+        when(userRepository.findByUsername("janedoe")).thenReturn(Optional.of(activeUser));
+        when(passwordEncoder.matches("rawPassword", "encodedPass")).thenReturn(false);
+
+        assertThatThrownBy(() -> loginUserUseCase.execute(request))
+                .isInstanceOf(InvalidCredentialsException.class);
+
+        verify(jwtUtil, never()).generateToken(any());
+    }
+
+    @Test
+    void execute_shouldThrowUserInactive_whenUserIsDisabled() {
+        activeUser.deactivate();
+
+        when(userRepository.findByUsername("janedoe")).thenReturn(Optional.of(activeUser));
+        when(passwordEncoder.matches("rawPassword", "encodedPass")).thenReturn(true);
+
+        assertThatThrownBy(() -> loginUserUseCase.execute(request))
+                .isInstanceOf(UserInactiveException.class);
+
+        verify(jwtUtil, never()).generateToken(any());
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientUseCaseTest.java
@@ -1,0 +1,63 @@
+package com.qiromanager.qiromanager_backend.application.patients;
+
+import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.api.patients.UpdatePatientRequest;
+import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdatePatientUseCaseTest {
+
+    @Mock
+    private PatientRepository patientRepository;
+
+    @InjectMocks
+    private UpdatePatientUseCase updatePatientUseCase;
+
+    @Test
+    void execute_shouldUpdatePatient_whenExists() {
+        Patient patient = Patient.create("Old Name", LocalDate.of(1990, 1, 1), null, null, null, null);
+
+        UpdatePatientRequest request = new UpdatePatientRequest();
+        request.setFullName("New Name");
+        request.setDateOfBirth(LocalDate.of(1990, 1, 1));
+        request.setEmail("new@email.com");
+        request.setPhone("600111222");
+
+        when(patientRepository.findById(1L)).thenReturn(Optional.of(patient));
+        when(patientRepository.save(any(Patient.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PatientResponse response = updatePatientUseCase.execute(1L, request);
+
+        assertThat(response.getFullName()).isEqualTo("New Name");
+        assertThat(response.getEmail()).isEqualTo("new@email.com");
+        verify(patientRepository).save(patient);
+    }
+
+    @Test
+    void execute_shouldThrow_whenPatientNotFound() {
+        when(patientRepository.findById(99L)).thenReturn(Optional.empty());
+
+        UpdatePatientRequest request = new UpdatePatientRequest();
+        request.setFullName("Name");
+
+        assertThatThrownBy(() -> updatePatientUseCase.execute(99L, request))
+                .isInstanceOf(PatientNotFoundException.class);
+
+        verify(patientRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserStatusUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserStatusUseCaseTest.java
@@ -1,0 +1,78 @@
+package com.qiromanager.qiromanager_backend.application.users;
+
+import com.qiromanager.qiromanager_backend.api.users.UpdateUserStatusRequest;
+import com.qiromanager.qiromanager_backend.api.users.UserResponse;
+import com.qiromanager.qiromanager_backend.domain.exceptions.UserNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateUserStatusUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UpdateUserStatusUseCase updateUserStatusUseCase;
+
+    @Test
+    void execute_shouldActivateUser_whenRequestIsTrue() {
+        User user = User.create("Jane Doe", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        user.deactivate();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateUserStatusRequest request = new UpdateUserStatusRequest();
+        request.setActive(true);
+
+        UserResponse response = updateUserStatusUseCase.execute(1L, request);
+
+        assertThat(response.isActive()).isTrue();
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void execute_shouldDeactivateUser_whenRequestIsFalse() {
+        User user = User.create("Jane Doe", "janedoe", "jane@clinic.com", "pass", Role.USER);
+
+        assertThat(user.isActive()).isTrue();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateUserStatusRequest request = new UpdateUserStatusRequest();
+        request.setActive(false);
+
+        UserResponse response = updateUserStatusUseCase.execute(1L, request);
+
+        assertThat(response.isActive()).isFalse();
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void execute_shouldThrow_whenUserNotFound() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        UpdateUserStatusRequest request = new UpdateUserStatusRequest();
+        request.setActive(true);
+
+        assertThatThrownBy(() -> updateUserStatusUseCase.execute(99L, request))
+                .isInstanceOf(UserNotFoundException.class);
+
+        verify(userRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserUseCaseTest.java
@@ -1,0 +1,134 @@
+package com.qiromanager.qiromanager_backend.application.users;
+
+import com.qiromanager.qiromanager_backend.api.users.UpdateUserRequest;
+import com.qiromanager.qiromanager_backend.api.users.UserResponse;
+import com.qiromanager.qiromanager_backend.domain.exceptions.UserAlreadyExistsException;
+import com.qiromanager.qiromanager_backend.domain.exceptions.UserNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateUserUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UpdateUserUseCase updateUserUseCase;
+
+    private User existingUser;
+
+    @BeforeEach
+    void setUp() {
+        existingUser = User.create("Jane Doe", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        existingUser.forceId(1L);
+    }
+
+    @Test
+    void execute_shouldUpdateUser_whenDataIsValid() {
+        UpdateUserRequest request = new UpdateUserRequest();
+        request.setFullName("Jane Updated");
+        request.setUsername("janedoe");
+        request.setEmail("jane@clinic.com");
+        request.setRole("ADMIN");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByUsername("janedoe")).thenReturn(Optional.of(existingUser)); // same user
+        when(userRepository.findByEmail("jane@clinic.com")).thenReturn(Optional.of(existingUser)); // same user
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserResponse response = updateUserUseCase.execute(1L, request);
+
+        assertThat(response.getFullName()).isEqualTo("Jane Updated");
+        assertThat(response.getRole()).isEqualTo("ADMIN");
+        verify(userRepository).save(existingUser);
+    }
+
+    @Test
+    void execute_shouldThrow_whenUserNotFound() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        UpdateUserRequest request = new UpdateUserRequest();
+        request.setFullName("Name");
+        request.setUsername("user");
+        request.setEmail("user@test.com");
+
+        assertThatThrownBy(() -> updateUserUseCase.execute(99L, request))
+                .isInstanceOf(UserNotFoundException.class);
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_shouldThrow_whenUsernameAlreadyTakenByAnotherUser() {
+        User otherUser = User.create("Other", "takenusername", "other@clinic.com", "pass", Role.USER);
+        otherUser.forceId(2L);
+
+        UpdateUserRequest request = new UpdateUserRequest();
+        request.setFullName("Jane");
+        request.setUsername("takenusername");
+        request.setEmail("jane@clinic.com");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByUsername("takenusername")).thenReturn(Optional.of(otherUser));
+
+        assertThatThrownBy(() -> updateUserUseCase.execute(1L, request))
+                .isInstanceOf(UserAlreadyExistsException.class)
+                .hasMessageContaining("Username");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_shouldThrow_whenEmailAlreadyTakenByAnotherUser() {
+        User otherUser = User.create("Other", "other", "taken@clinic.com", "pass", Role.USER);
+        otherUser.forceId(2L);
+
+        UpdateUserRequest request = new UpdateUserRequest();
+        request.setFullName("Jane");
+        request.setUsername("janedoe");
+        request.setEmail("taken@clinic.com");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByUsername("janedoe")).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByEmail("taken@clinic.com")).thenReturn(Optional.of(otherUser));
+
+        assertThatThrownBy(() -> updateUserUseCase.execute(1L, request))
+                .isInstanceOf(UserAlreadyExistsException.class)
+                .hasMessageContaining("Email");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_shouldAllowUpdate_whenUsernameAndEmailBelongToSameUser() {
+        UpdateUserRequest request = new UpdateUserRequest();
+        request.setFullName("Jane Doe");
+        request.setUsername("janedoe");
+        request.setEmail("jane@clinic.com");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByUsername("janedoe")).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByEmail("jane@clinic.com")).thenReturn(Optional.of(existingUser));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserResponse response = updateUserUseCase.execute(1L, request);
+
+        assertThat(response).isNotNull();
+        verify(userRepository).save(existingUser);
+    }
+}


### PR DESCRIPTION
## Summary
- 4 new unit test classes covering authentication and user/patient update logic
- All 14 tests pass with no Spring context needed (pure Mockito)

## New tests

| Test class | Scenarios covered |
|---|---|
| `LoginUserUseCaseTest` | Successful login; user not found → 401; wrong password → 401; inactive user → 403 |
| `UpdatePatientUseCaseTest` | Successful update; patient not found |
| `UpdateUserStatusUseCaseTest` | Activate user; deactivate user; user not found |
| `UpdateUserUseCaseTest` | Successful update; user not found; username taken by another user; email taken by another user; same credentials allowed for same user |

## Test plan
- [ ] All 14 new tests pass (`mvnw test`)
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)