### PR TITLE
test: add unit tests for remaining use cases

### DIFF
--- a/src/test/java/com/qiromanager/qiromanager_backend/application/patients/GetPatientByIdUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/patients/GetPatientByIdUseCaseTest.java
@@ -1,0 +1,48 @@
+package com.qiromanager.qiromanager_backend.application.patients;
+
+import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetPatientByIdUseCaseTest {
+
+    @Mock
+    private PatientRepository patientRepository;
+
+    @InjectMocks
+    private GetPatientByIdUseCase getPatientByIdUseCase;
+
+    @Test
+    void execute_shouldReturnPatient_whenExists() {
+        Patient patient = Patient.create("John Patient", LocalDate.of(1990, 1, 1), "600111222", "john@test.com", null, null);
+
+        when(patientRepository.findById(1L)).thenReturn(Optional.of(patient));
+
+        PatientResponse response = getPatientByIdUseCase.execute(1L);
+
+        assertThat(response.getFullName()).isEqualTo("John Patient");
+        assertThat(response.getEmail()).isEqualTo("john@test.com");
+    }
+
+    @Test
+    void execute_shouldThrow_whenPatientNotFound() {
+        when(patientRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getPatientByIdUseCase.execute(99L))
+                .isInstanceOf(PatientNotFoundException.class);
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/stats/GetDashboardStatsUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/stats/GetDashboardStatsUseCaseTest.java
@@ -1,0 +1,84 @@
+package com.qiromanager.qiromanager_backend.application.stats;
+
+import com.qiromanager.qiromanager_backend.api.stats.DashboardStatsResponse;
+import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
+import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSessionRepository;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetDashboardStatsUseCaseTest {
+
+    @Mock
+    private PatientRepository patientRepository;
+
+    @Mock
+    private TreatmentSessionRepository treatmentSessionRepository;
+
+    @Mock
+    private AuthenticatedUserService authenticatedUserService;
+
+    @InjectMocks
+    private GetDashboardStatsUseCase getDashboardStatsUseCase;
+
+    @BeforeEach
+    void setUp() {
+        when(patientRepository.countAll()).thenReturn(50L);
+        when(patientRepository.countActive()).thenReturn(40L);
+    }
+
+    @Test
+    void execute_shouldReturnGlobalSessionCount_whenUserIsAdmin() {
+        User admin = User.create("Admin", "admin", "admin@clinic.com", "pass", Role.ADMIN);
+        admin.forceId(1L);
+
+        when(authenticatedUserService.getCurrentUser()).thenReturn(admin);
+        when(authenticatedUserService.isAdmin(admin)).thenReturn(true);
+        when(patientRepository.countByTherapistId(1L)).thenReturn(10L);
+        when(treatmentSessionRepository.countSessionsBetween(any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(25L);
+
+        DashboardStatsResponse response = getDashboardStatsUseCase.execute();
+
+        assertThat(response.getTotalPatients()).isEqualTo(50L);
+        assertThat(response.getActivePatients()).isEqualTo(40L);
+        assertThat(response.getSessionsThisMonth()).isEqualTo(25L);
+
+        verify(treatmentSessionRepository).countSessionsBetween(any(), any());
+        verify(treatmentSessionRepository, never()).countTherapistSessionsBetween(any(), any(), any());
+    }
+
+    @Test
+    void execute_shouldReturnTherapistSessionCount_whenUserIsNotAdmin() {
+        User therapist = User.create("Jane", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        therapist.forceId(2L);
+
+        when(authenticatedUserService.getCurrentUser()).thenReturn(therapist);
+        when(authenticatedUserService.isAdmin(therapist)).thenReturn(false);
+        when(patientRepository.countByTherapistId(2L)).thenReturn(8L);
+        when(treatmentSessionRepository.countTherapistSessionsBetween(eq(2L), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(5L);
+
+        DashboardStatsResponse response = getDashboardStatsUseCase.execute();
+
+        assertThat(response.getSessionsThisMonth()).isEqualTo(5L);
+        assertThat(response.getMyAssignedPatients()).isEqualTo(8L);
+
+        verify(treatmentSessionRepository).countTherapistSessionsBetween(eq(2L), any(), any());
+        verify(treatmentSessionRepository, never()).countSessionsBetween(any(), any());
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/treatments/GetPatientTreatmentSessionsUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/treatments/GetPatientTreatmentSessionsUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.qiromanager.qiromanager_backend.application.treatments;
+
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSession;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSessionRepository;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetPatientTreatmentSessionsUseCaseTest {
+
+    @Mock
+    private TreatmentSessionRepository treatmentSessionRepository;
+
+    @InjectMocks
+    private GetPatientTreatmentSessionsUseCase getPatientTreatmentSessionsUseCase;
+
+    @Test
+    void execute_shouldReturnSessions_forPatient() {
+        Patient patient = Patient.create("John Patient", LocalDate.of(1990, 1, 1), null, null, null, null);
+        User therapist = User.create("Jane", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        TreatmentSession session = TreatmentSession.create(patient, therapist, LocalDateTime.now(), "First session notes");
+
+        when(treatmentSessionRepository.findByPatientId(1L)).thenReturn(List.of(session));
+
+        List<TreatmentSession> result = getPatientTreatmentSessionsUseCase.execute(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getNotes()).isEqualTo("First session notes");
+    }
+
+    @Test
+    void execute_shouldReturnEmptyList_whenNoSessions() {
+        when(treatmentSessionRepository.findByPatientId(99L)).thenReturn(Collections.emptyList());
+
+        List<TreatmentSession> result = getPatientTreatmentSessionsUseCase.execute(99L);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserProfileUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserProfileUseCaseTest.java
@@ -1,0 +1,97 @@
+package com.qiromanager.qiromanager_backend.application.users;
+
+import com.qiromanager.qiromanager_backend.api.users.UpdateUserProfileRequest;
+import com.qiromanager.qiromanager_backend.api.users.UserResponse;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateUserProfileUseCaseTest {
+
+    @Mock
+    private AuthenticatedUserService authenticatedUserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UpdateUserProfileUseCase updateUserProfileUseCase;
+
+    private User currentUser;
+
+    @BeforeEach
+    void setUp() {
+        currentUser = User.create("Jane Doe", "janedoe", "jane@clinic.com", "encodedOldPass", Role.USER);
+        currentUser.forceId(1L);
+        when(authenticatedUserService.getCurrentUser()).thenReturn(currentUser);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void execute_shouldUpdateFullName_whenProvided() {
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest();
+        request.setFullName("Jane Updated");
+
+        UserResponse response = updateUserProfileUseCase.execute(request);
+
+        assertThat(response.getFullName()).isEqualTo("Jane Updated");
+        verify(passwordEncoder, never()).encode(any());
+        verify(userRepository).save(currentUser);
+    }
+
+    @Test
+    void execute_shouldChangePassword_whenProvided() {
+        when(passwordEncoder.encode("newPassword123")).thenReturn("encodedNewPass");
+
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest();
+        request.setPassword("newPassword123");
+
+        updateUserProfileUseCase.execute(request);
+
+        verify(passwordEncoder).encode("newPassword123");
+        assertThat(currentUser.getPassword()).isEqualTo("encodedNewPass");
+        verify(userRepository).save(currentUser);
+    }
+
+    @Test
+    void execute_shouldUpdateBoth_whenBothFieldsProvided() {
+        when(passwordEncoder.encode("newPassword123")).thenReturn("encodedNewPass");
+
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest();
+        request.setFullName("Jane Updated");
+        request.setPassword("newPassword123");
+
+        UserResponse response = updateUserProfileUseCase.execute(request);
+
+        assertThat(response.getFullName()).isEqualTo("Jane Updated");
+        verify(passwordEncoder).encode("newPassword123");
+        verify(userRepository).save(currentUser);
+    }
+
+    @Test
+    void execute_shouldSave_withoutChanges_whenBothFieldsAreBlank() {
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest();
+        request.setFullName("  ");
+        request.setPassword("  ");
+
+        updateUserProfileUseCase.execute(request);
+
+        verify(passwordEncoder, never()).encode(any());
+        verify(userRepository).save(currentUser);
+    }
+}


### PR DESCRIPTION
## Summary
- 4 new unit test classes covering the remaining medium-priority use cases
- All 10 tests pass with no Spring context needed (pure Mockito)

## New tests

| Test class | Scenarios covered |
|---|---|
| `GetPatientByIdUseCaseTest` | Patient found; patient not found |
| `UpdateUserProfileUseCaseTest` | Update name only; change password only; update both; no-op when fields are blank |
| `GetDashboardStatsUseCaseTest` | Admin sees global session count; therapist sees only own sessions |
| `GetPatientTreatmentSessionsUseCaseTest` | Returns sessions list; returns empty list when no sessions |

## Test plan
- [ ] All 10 new tests pass (`mvnw test`)
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)