### PR TITLE
feat: add OpenAPI documentation and JWT security scheme

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/api/auth/AuthController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/auth/AuthController.java
@@ -2,6 +2,11 @@ package com.qiromanager.qiromanager_backend.api.auth;
 
 import com.qiromanager.qiromanager_backend.application.auth.LoginUserUseCase;
 import com.qiromanager.qiromanager_backend.application.auth.RegisterUserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
+@Tag(name = "Authentication", description = "Register and login endpoints. No token required.")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -18,6 +24,12 @@ public class AuthController {
     private final RegisterUserUseCase registerUserUseCase;
     private final LoginUserUseCase loginUserUseCase;
 
+    @Operation(summary = "Register a new user (ADMIN only in production)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User registered successfully"),
+            @ApiResponse(responseCode = "409", description = "Username or email already exists")
+    })
+    @SecurityRequirements
     @PostMapping("/register")
     public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
         log.info("Request received: Register new user with username: {}", request.getUsername());
@@ -28,6 +40,13 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Login and obtain a JWT token")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Login successful, returns JWT token"),
+            @ApiResponse(responseCode = "401", description = "Invalid username or password"),
+            @ApiResponse(responseCode = "403", description = "Account is inactive")
+    })
+    @SecurityRequirements
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         log.info("Request received: Login attempt for username: {}", request.getUsername());

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/ClinicalRecordController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/ClinicalRecordController.java
@@ -2,6 +2,10 @@ package com.qiromanager.qiromanager_backend.api.clinicalrecords;
 
 import com.qiromanager.qiromanager_backend.application.clinicalrecords.CreateClinicalRecordUseCase;
 import com.qiromanager.qiromanager_backend.application.clinicalrecords.GetPatientClinicalRecordsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Tag(name = "Clinical Records", description = "Create and retrieve clinical history records for a patient. Requires JWT.")
 @RestController
 @RequestMapping("/api/v1/patients")
 @RequiredArgsConstructor
@@ -22,6 +27,12 @@ public class ClinicalRecordController {
     private final CreateClinicalRecordUseCase createClinicalRecordUseCase;
     private final GetPatientClinicalRecordsUseCase getPatientClinicalRecordsUseCase;
 
+    @Operation(summary = "Create a clinical record for a patient (supports optional file attachment)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Clinical record created"),
+            @ApiResponse(responseCode = "400", description = "Invalid file type or size"),
+            @ApiResponse(responseCode = "404", description = "Patient not found")
+    })
     @PostMapping(value = "/{patientId}/clinical-records", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<ClinicalRecordResponse> createClinicalRecord(
@@ -39,6 +50,8 @@ public class ClinicalRecordController {
         return ResponseEntity.status(201).body(response);
     }
 
+    @Operation(summary = "Get all clinical records for a patient")
+    @ApiResponse(responseCode = "200", description = "List of clinical records")
     @GetMapping("/{patientId}/clinical-records")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<List<ClinicalRecordResponse>> getClinicalRecords(

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/patients/PatientController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/patients/PatientController.java
@@ -2,6 +2,10 @@ package com.qiromanager.qiromanager_backend.api.patients;
 
 import com.qiromanager.qiromanager_backend.api.common.PageResponse;
 import com.qiromanager.qiromanager_backend.application.patients.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Patients", description = "Create, read, update and manage patient assignments. Requires JWT.")
 @RestController
 @RequestMapping("/api/v1/patients")
 @RequiredArgsConstructor
@@ -27,6 +32,11 @@ public class PatientController {
     private final AssignPatientUseCase assignPatientUseCase;
     private final UnassignPatientUseCase unassignPatientUseCase;
 
+    @Operation(summary = "Create a new patient (auto-assigned to the calling therapist)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Patient created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request data")
+    })
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @PostMapping
     public ResponseEntity<PatientResponse> createPatient(
@@ -40,6 +50,8 @@ public class PatientController {
         return ResponseEntity.status(201).body(response);
     }
 
+    @Operation(summary = "List all active patients (paginated). Use assignedToMe=true to filter by current therapist.")
+    @ApiResponse(responseCode = "200", description = "Paginated list of patients")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping
     public ResponseEntity<PageResponse<PatientResponse>> getAllPatients(
@@ -56,6 +68,11 @@ public class PatientController {
         return ResponseEntity.ok(PageResponse.from(patients));
     }
 
+    @Operation(summary = "Get patient details by ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Patient found"),
+            @ApiResponse(responseCode = "404", description = "Patient not found")
+    })
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping("/{id}")
     public ResponseEntity<PatientResponse> getPatientById(@PathVariable Long id) {
@@ -67,6 +84,11 @@ public class PatientController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Update patient data")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Patient updated successfully"),
+            @ApiResponse(responseCode = "404", description = "Patient not found")
+    })
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<PatientResponse> updatePatient(
@@ -81,6 +103,11 @@ public class PatientController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Activate or deactivate a patient (ADMIN only)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Status updated successfully"),
+            @ApiResponse(responseCode = "404", description = "Patient not found")
+    })
     @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{id}/status")
     public ResponseEntity<PatientResponse> updatePatientStatus(
@@ -95,6 +122,8 @@ public class PatientController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Search patients by full name (paginated)")
+    @ApiResponse(responseCode = "200", description = "Paginated search results")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping("/search")
     public ResponseEntity<PageResponse<PatientResponse>> searchPatients(
@@ -110,6 +139,11 @@ public class PatientController {
         return ResponseEntity.ok(PageResponse.from(results));
     }
 
+    @Operation(summary = "Assign the calling therapist to a patient")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Assigned successfully (idempotent)"),
+            @ApiResponse(responseCode = "404", description = "Patient not found")
+    })
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @PostMapping("/{id}/assign")
     public ResponseEntity<PatientResponse> assignPatient(@PathVariable Long id) {
@@ -121,6 +155,11 @@ public class PatientController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Remove the calling therapist from a patient")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Unassigned successfully (no-op if not assigned)"),
+            @ApiResponse(responseCode = "404", description = "Patient not found")
+    })
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @DeleteMapping("/{id}/assign")
     public ResponseEntity<PatientResponse> unassignPatient(@PathVariable Long id) {

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/stats/StatsController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/stats/StatsController.java
@@ -1,6 +1,9 @@
 package com.qiromanager.qiromanager_backend.api.stats;
 
 import com.qiromanager.qiromanager_backend.application.stats.GetDashboardStatsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -8,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Dashboard Stats", description = "Aggregated statistics for the dashboard. Requires JWT.")
 @RestController
 @RequestMapping("/api/v1/stats")
 @RequiredArgsConstructor
@@ -15,6 +19,8 @@ public class StatsController {
 
     private final GetDashboardStatsUseCase getDashboardStatsUseCase;
 
+    @Operation(summary = "Get dashboard stats. Admins see global data; therapists see their own.")
+    @ApiResponse(responseCode = "200", description = "Dashboard statistics")
     @GetMapping
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<DashboardStatsResponse> getDashboardStats() {

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/treatments/TreatmentSessionController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/treatments/TreatmentSessionController.java
@@ -3,6 +3,10 @@ package com.qiromanager.qiromanager_backend.api.treatments;
 import com.qiromanager.qiromanager_backend.api.mappers.TreatmentSessionMapper;
 import com.qiromanager.qiromanager_backend.application.treatments.CreateTreatmentSessionUseCase;
 import com.qiromanager.qiromanager_backend.application.treatments.GetPatientTreatmentSessionsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Treatment Sessions", description = "Log and retrieve treatment sessions for a patient. Requires JWT.")
 @RestController
 @RequestMapping("/api/v1/patients")
 @RequiredArgsConstructor
@@ -22,6 +27,11 @@ public class TreatmentSessionController {
     private final GetPatientTreatmentSessionsUseCase getPatientTreatmentSessionsUseCase;
     private final TreatmentSessionMapper treatmentSessionMapper;
 
+    @Operation(summary = "Log a new treatment session for a patient")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Session logged successfully"),
+            @ApiResponse(responseCode = "404", description = "Patient not found")
+    })
     @PostMapping("/{patientId}/sessions")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<TreatmentSessionResponse> createSession(
@@ -37,6 +47,8 @@ public class TreatmentSessionController {
         return ResponseEntity.status(201).body(response);
     }
 
+    @Operation(summary = "Get all treatment sessions for a patient")
+    @ApiResponse(responseCode = "200", description = "List of treatment sessions")
     @GetMapping("/{patientId}/sessions")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<List<TreatmentSessionResponse>> getSessionsByPatient(@PathVariable Long patientId) {

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/users/UserController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/users/UserController.java
@@ -3,6 +3,10 @@ package com.qiromanager.qiromanager_backend.api.users;
 import com.qiromanager.qiromanager_backend.api.mappers.UserMapper;
 import com.qiromanager.qiromanager_backend.application.users.*;
 import com.qiromanager.qiromanager_backend.domain.user.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Users", description = "User management. Admin endpoints require ADMIN role.")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -25,6 +30,8 @@ public class UserController {
     private final GetAuthenticatedUserUseCase getAuthenticatedUserUseCase;
     private final UpdateUserProfileUseCase updateUserProfileUseCase;
 
+    @Operation(summary = "List all users (ADMIN only)")
+    @ApiResponse(responseCode = "200", description = "List of all users")
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<UserResponse>> getAllUsers() {
@@ -38,6 +45,11 @@ public class UserController {
                 .toList());
     }
 
+    @Operation(summary = "Get user by ID (ADMIN only)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User found"),
+            @ApiResponse(responseCode = "404", description = "User not found")
+    })
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<UserResponse> getUserById(@PathVariable Long id) {
@@ -46,6 +58,8 @@ public class UserController {
         return ResponseEntity.ok(UserMapper.toResponse(user));
     }
 
+    @Operation(summary = "Get the profile of the authenticated user")
+    @ApiResponse(responseCode = "200", description = "Authenticated user profile")
     @GetMapping("/me")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<UserResponse> getMe() {
@@ -55,6 +69,8 @@ public class UserController {
         return ResponseEntity.ok(UserMapper.toResponse(myUser));
     }
 
+    @Operation(summary = "Update own name and/or password")
+    @ApiResponse(responseCode = "200", description = "Profile updated successfully")
     @PutMapping("/me")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<UserResponse> updateMyProfile(
@@ -65,6 +81,12 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Update any user's data including role (ADMIN only)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User updated successfully"),
+            @ApiResponse(responseCode = "404", description = "User not found"),
+            @ApiResponse(responseCode = "409", description = "Username or email already taken")
+    })
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<UserResponse> updateUser(
@@ -78,6 +100,11 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Activate or deactivate a user account (ADMIN only)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Status updated successfully"),
+            @ApiResponse(responseCode = "404", description = "User not found")
+    })
     @PatchMapping("/{id}/status")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<UserResponse> updateUserStatus(

--- a/src/main/java/com/qiromanager/qiromanager_backend/config/OpenAPIConfig.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/config/OpenAPIConfig.java
@@ -1,19 +1,31 @@
 package com.qiromanager.qiromanager_backend.config;
 
-import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenAPIConfig {
 
+    private static final String BEARER_SCHEME = "bearerAuth";
+
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("Qiromanager API")
-                        .description("Backend API for the Qiromanager system")
-                        .version("1.0.0"));
+                        .description("Backend API for the Qiromanager clinic management system")
+                        .version("1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_SCHEME, new SecurityScheme()
+                                .name(BEARER_SCHEME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }


### PR DESCRIPTION
## Summary
- Added JWT Bearer security scheme so Swagger UI shows the **Authorize 🔒** button — all protected endpoints now work from the UI after pasting a token
- Added `@Tag` to all 5 controllers to group endpoints by domain in the Swagger UI
- Added `@Operation` + `@ApiResponse` to every endpoint describing its purpose and possible HTTP status codes
- Marked `POST /auth/login` and `POST /auth/register` with `@SecurityRequirements` so they appear as public in Swagger UI

## Result in Swagger UI
```
📁 Authentication    — register, login (no auth required)
📁 Patients          — CRUD + assign/unassign + search + list
📁 Users             — list, get by ID, me, update profile, update status
📁 Treatment Sessions — log session, list sessions
📁 Clinical Records  — create record (with file), list records
📁 Dashboard Stats   — get dashboard stats
```

## Test plan
- [ ] App starts successfully
- [ ] Swagger UI accessible at `/swagger-ui.html`
- [ ] Authorize button visible, JWT token accepted
- [ ] All endpoints show correct descriptions and response codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)