### PR TITLE
feat: add auditing with Spring Data Auditing and custom AuditLog table

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/QiromanagerBackendApplication.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/QiromanagerBackendApplication.java
@@ -3,9 +3,11 @@ package com.qiromanager.qiromanager_backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableCaching
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
 public class QiromanagerBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/audit/AuditService.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/audit/AuditService.java
@@ -1,0 +1,33 @@
+package com.qiromanager.qiromanager_backend.application.audit;
+
+import com.qiromanager.qiromanager_backend.domain.audit.AuditAction;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditLog;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuditService {
+
+    private final AuditLogRepository auditLogRepository;
+
+    public void log(String entityType, Long entityId, AuditAction action, String details) {
+        String performedBy = resolveCurrentUser();
+        AuditLog entry = AuditLog.create(entityType, entityId, action, performedBy, details);
+        auditLogRepository.save(entry);
+        log.debug("Audit: {} on {} ID={} by {}", action, entityType, entityId, performedBy);
+    }
+
+    private String resolveCurrentUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return "system";
+        }
+        return auth.getName();
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/patients/AssignPatientUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/patients/AssignPatientUseCase.java
@@ -2,7 +2,9 @@ package com.qiromanager.qiromanager_backend.application.patients;
 
 import com.qiromanager.qiromanager_backend.api.mappers.PatientMapper;
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditAction;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
@@ -20,6 +22,7 @@ public class AssignPatientUseCase {
 
     private final PatientRepository patientRepository;
     private final AuthenticatedUserService authenticatedUserService;
+    private final AuditService auditService;
 
     @Transactional
     @CacheEvict(value = "patients", key = "#patientId")
@@ -37,6 +40,8 @@ public class AssignPatientUseCase {
                     currentUser.getUsername(), patient.getFullName(), patientId);
 
             patient.assignTherapist(currentUser);
+            auditService.log("Patient", patientId, AuditAction.PATIENT_ASSIGNED,
+                    "Assigned to therapist: " + currentUser.getUsername());
         } else {
             log.debug("Therapist '{}' was already assigned to patient '{}'",
                     currentUser.getUsername(), patient.getFullName());

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/patients/CreatePatientUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/patients/CreatePatientUseCase.java
@@ -3,7 +3,9 @@ package com.qiromanager.qiromanager_backend.application.patients;
 import com.qiromanager.qiromanager_backend.api.mappers.PatientMapper;
 import com.qiromanager.qiromanager_backend.api.patients.CreatePatientRequest;
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditAction;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
 import com.qiromanager.qiromanager_backend.domain.user.User;
@@ -12,8 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -21,6 +21,7 @@ public class CreatePatientUseCase {
 
     private final PatientRepository patientRepository;
     private final AuthenticatedUserService authenticatedUserService;
+    private final AuditService auditService;
 
     @Transactional
     public PatientResponse execute(CreatePatientRequest request) {
@@ -41,6 +42,7 @@ public class CreatePatientUseCase {
         Patient saved = patientRepository.save(patient);
 
         log.info("New patient created: {} (ID: {})", saved.getFullName(), saved.getId());
+        auditService.log("Patient", saved.getId(), AuditAction.PATIENT_CREATED, null);
 
         return PatientMapper.toResponse(saved);
     }

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/patients/UnassignPatientUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/patients/UnassignPatientUseCase.java
@@ -2,7 +2,9 @@ package com.qiromanager.qiromanager_backend.application.patients;
 
 import com.qiromanager.qiromanager_backend.api.mappers.PatientMapper;
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditAction;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
@@ -20,6 +22,7 @@ public class UnassignPatientUseCase {
 
     private final PatientRepository patientRepository;
     private final AuthenticatedUserService authenticatedUserService;
+    private final AuditService auditService;
 
     @Transactional
     @CacheEvict(value = "patients", key = "#patientId")
@@ -42,6 +45,8 @@ public class UnassignPatientUseCase {
                 currentUser.getUsername(), patient.getFullName(), patientId);
 
         patient.unassignTherapist(currentUser);
+        auditService.log("Patient", patientId, AuditAction.PATIENT_UNASSIGNED,
+                "Unassigned from therapist: " + currentUser.getUsername());
 
         Patient updated = patientRepository.save(patient);
 

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientStatusUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientStatusUseCase.java
@@ -3,6 +3,8 @@ package com.qiromanager.qiromanager_backend.application.patients;
 import com.qiromanager.qiromanager_backend.api.mappers.PatientMapper;
 import com.qiromanager.qiromanager_backend.api.patients.UpdatePatientStatusRequest;
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditAction;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdatePatientStatusUseCase {
 
     private final PatientRepository patientRepository;
+    private final AuditService auditService;
 
     @Transactional
     @CacheEvict(value = "patients", key = "#id")
@@ -26,15 +29,19 @@ public class UpdatePatientStatusUseCase {
         Patient patient = patientRepository.findById(id)
                 .orElseThrow(() -> new PatientNotFoundException(id));
 
+        AuditAction action;
         if (Boolean.TRUE.equals(request.getActive())) {
             patient.activate();
+            action = AuditAction.PATIENT_ACTIVATED;
             log.info("Patient ID: {} status changed to ACTIVE", id);
         } else {
             patient.deactivate();
+            action = AuditAction.PATIENT_DEACTIVATED;
             log.info("Patient ID: {} status changed to INACTIVE", id);
         }
 
         Patient updated = patientRepository.save(patient);
+        auditService.log("Patient", id, action, null);
 
         return PatientMapper.toResponse(updated);
     }

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientUseCase.java
@@ -3,6 +3,8 @@ package com.qiromanager.qiromanager_backend.application.patients;
 import com.qiromanager.qiromanager_backend.api.mappers.PatientMapper;
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
 import com.qiromanager.qiromanager_backend.api.patients.UpdatePatientRequest;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditAction;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdatePatientUseCase {
 
     private final PatientRepository patientRepository;
+    private final AuditService auditService;
 
     @Transactional
     @CacheEvict(value = "patients", key = "#id")
@@ -37,6 +40,7 @@ public class UpdatePatientUseCase {
 
         Patient updated = patientRepository.save(patient);
         log.info("Patient ID: {} updated successfully", id);
+        auditService.log("Patient", id, AuditAction.PATIENT_UPDATED, null);
 
         return PatientMapper.toResponse(updated);
     }

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserStatusUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserStatusUseCase.java
@@ -3,6 +3,8 @@ package com.qiromanager.qiromanager_backend.application.users;
 import com.qiromanager.qiromanager_backend.api.mappers.UserMapper;
 import com.qiromanager.qiromanager_backend.api.users.UpdateUserStatusRequest;
 import com.qiromanager.qiromanager_backend.api.users.UserResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditAction;
 import com.qiromanager.qiromanager_backend.domain.exceptions.UserNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.user.User;
 import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateUserStatusUseCase {
 
     private final UserRepository userRepository;
+    private final AuditService auditService;
 
     @Transactional
     public UserResponse execute(Long id, UpdateUserStatusRequest request) {
@@ -24,15 +27,19 @@ public class UpdateUserStatusUseCase {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new UserNotFoundException(id));
 
+        AuditAction action;
         if (Boolean.TRUE.equals(request.getActive())) {
             user.activate();
+            action = AuditAction.USER_ACTIVATED;
             log.info("User ID: {} status changed to ACTIVE", id);
         } else {
             user.deactivate();
+            action = AuditAction.USER_DEACTIVATED;
             log.info("User ID: {} status changed to INACTIVE", id);
         }
 
         User savedUser = userRepository.save(user);
+        auditService.log("User", id, action, null);
         return UserMapper.toResponse(savedUser);
     }
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/config/AuditorAwareImpl.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/config/AuditorAwareImpl.java
@@ -1,0 +1,21 @@
+package com.qiromanager.qiromanager_backend.config;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return Optional.of("system");
+        }
+        return Optional.of(auth.getName());
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/audit/AuditAction.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/audit/AuditAction.java
@@ -1,0 +1,12 @@
+package com.qiromanager.qiromanager_backend.domain.audit;
+
+public enum AuditAction {
+    PATIENT_CREATED,
+    PATIENT_UPDATED,
+    PATIENT_ACTIVATED,
+    PATIENT_DEACTIVATED,
+    PATIENT_ASSIGNED,
+    PATIENT_UNASSIGNED,
+    USER_ACTIVATED,
+    USER_DEACTIVATED
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/audit/AuditLog.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/audit/AuditLog.java
@@ -1,0 +1,54 @@
+package com.qiromanager.qiromanager_backend.domain.audit;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "audit_log")
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String entityType;
+
+    @Column(nullable = false)
+    private Long entityId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuditAction action;
+
+    @Column(nullable = false)
+    private String performedBy;
+
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+
+    private String details;
+
+    protected AuditLog() {
+    }
+
+    private AuditLog(String entityType, Long entityId, AuditAction action, String performedBy, String details) {
+        this.entityType = entityType;
+        this.entityId = entityId;
+        this.action = action;
+        this.performedBy = performedBy;
+        this.details = details;
+    }
+
+    public static AuditLog create(String entityType, Long entityId, AuditAction action, String performedBy, String details) {
+        return new AuditLog(entityType, entityId, action, performedBy, details);
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.timestamp = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/audit/AuditLogRepository.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/audit/AuditLogRepository.java
@@ -1,0 +1,6 @@
+package com.qiromanager.qiromanager_backend.domain.audit;
+
+public interface AuditLogRepository {
+
+    AuditLog save(AuditLog auditLog);
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/patient/Patient.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/patient/Patient.java
@@ -4,6 +4,9 @@ import com.qiromanager.qiromanager_backend.domain.user.User;
 import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,6 +18,7 @@ import java.util.Set;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Entity
 @Table(name = "patients")
+@EntityListeners(AuditingEntityListener.class)
 public class Patient {
 
     @Id
@@ -48,6 +52,13 @@ public class Patient {
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String updatedBy;
 
     protected Patient() {
     }

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/user/User.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/user/User.java
@@ -2,12 +2,17 @@ package com.qiromanager.qiromanager_backend.domain.user;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EntityListeners(AuditingEntityListener.class)
 public class User {
 
     @Id
@@ -32,6 +37,13 @@ public class User {
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String updatedBy;
 
     protected User() {
 

--- a/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/audit/JpaAuditLogRepository.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/audit/JpaAuditLogRepository.java
@@ -1,0 +1,10 @@
+package com.qiromanager.qiromanager_backend.infrastructure.audit;
+
+import com.qiromanager.qiromanager_backend.domain.audit.AuditLog;
+import com.qiromanager.qiromanager_backend.domain.audit.AuditLogRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaAuditLogRepository extends JpaRepository<AuditLog, Long>, AuditLogRepository {
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/patients/AssignPatientUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/patients/AssignPatientUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.qiromanager.qiromanager_backend.application.patients;
 
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
@@ -30,6 +31,9 @@ class AssignPatientUseCaseTest {
 
     @Mock
     private AuthenticatedUserService authenticatedUserService;
+
+    @Mock
+    private AuditService auditService;
 
     @InjectMocks
     private AssignPatientUseCase assignPatientUseCase;

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/patients/CreatePatientUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/patients/CreatePatientUseCaseTest.java
@@ -2,6 +2,7 @@ package com.qiromanager.qiromanager_backend.application.patients;
 
 import com.qiromanager.qiromanager_backend.api.patients.CreatePatientRequest;
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
@@ -28,6 +29,9 @@ class CreatePatientUseCaseTest {
 
     @Mock
     private AuthenticatedUserService authenticatedUserService;
+
+    @Mock
+    private AuditService auditService;
 
     @InjectMocks
     private CreatePatientUseCase createPatientUseCase;

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/patients/UnassignPatientUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/patients/UnassignPatientUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.qiromanager.qiromanager_backend.application.patients;
 
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.application.users.AuthenticatedUserService;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
@@ -30,6 +31,9 @@ class UnassignPatientUseCaseTest {
 
     @Mock
     private AuthenticatedUserService authenticatedUserService;
+
+    @Mock
+    private AuditService auditService;
 
     @InjectMocks
     private UnassignPatientUseCase unassignPatientUseCase;

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientStatusUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientStatusUseCaseTest.java
@@ -2,6 +2,7 @@ package com.qiromanager.qiromanager_backend.application.patients;
 
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
 import com.qiromanager.qiromanager_backend.api.patients.UpdatePatientStatusRequest;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
@@ -24,6 +25,9 @@ class UpdatePatientStatusUseCaseTest {
 
     @Mock
     private PatientRepository patientRepository;
+
+    @Mock
+    private AuditService auditService;
 
     @InjectMocks
     private UpdatePatientStatusUseCase updatePatientStatusUseCase;

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/patients/UpdatePatientUseCaseTest.java
@@ -2,6 +2,7 @@ package com.qiromanager.qiromanager_backend.application.patients;
 
 import com.qiromanager.qiromanager_backend.api.patients.PatientResponse;
 import com.qiromanager.qiromanager_backend.api.patients.UpdatePatientRequest;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.domain.exceptions.PatientNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.patient.Patient;
 import com.qiromanager.qiromanager_backend.domain.patient.PatientRepository;
@@ -24,6 +25,9 @@ class UpdatePatientUseCaseTest {
 
     @Mock
     private PatientRepository patientRepository;
+
+    @Mock
+    private AuditService auditService;
 
     @InjectMocks
     private UpdatePatientUseCase updatePatientUseCase;

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserStatusUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/users/UpdateUserStatusUseCaseTest.java
@@ -2,6 +2,7 @@ package com.qiromanager.qiromanager_backend.application.users;
 
 import com.qiromanager.qiromanager_backend.api.users.UpdateUserStatusRequest;
 import com.qiromanager.qiromanager_backend.api.users.UserResponse;
+import com.qiromanager.qiromanager_backend.application.audit.AuditService;
 import com.qiromanager.qiromanager_backend.domain.exceptions.UserNotFoundException;
 import com.qiromanager.qiromanager_backend.domain.user.Role;
 import com.qiromanager.qiromanager_backend.domain.user.User;
@@ -24,6 +25,9 @@ class UpdateUserStatusUseCaseTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private AuditService auditService;
 
     @InjectMocks
     private UpdateUserStatusUseCase updateUserStatusUseCase;


### PR DESCRIPTION
## Summary
- **Spring Data Auditing**: `@EnableJpaAuditing` + `AuditorAwareImpl` adds `createdBy` / `updatedBy` columns to `patients` and `users` tables, auto-populated from the JWT-authenticated user
- **Custom `audit_log` table**: new `AuditLog` entity records 8 critical actions (patient/user status changes, patient creation/update, therapist assignment/unassignment) with entity type, ID, action, performer, timestamp, and optional details
- **`AuditService`**: thin application-layer service injected into 6 use cases; reads current user from `SecurityContextHolder` internally, keeping use case signatures clean
- **Tests**: existing unit tests updated to mock `AuditService` as the new constructor dependency — all 50 tests pass

## Test plan
- [ ] All 50 tests pass: `./mvnw test`
- [ ] Start in dev mode: verify `patients` table has `created_by` / `updated_by` columns
- [ ] Verify `audit_log` table is auto-created by Hibernate
- [ ] Create a patient → `audit_log` contains `PATIENT_CREATED` entry with correct `performed_by`
- [ ] Deactivate a patient → `audit_log` contains `PATIENT_DEACTIVATED` entry
- [ ] Assign therapist to patient → `audit_log` contains `PATIENT_ASSIGNED` with therapist username in `details`

🤖 Generated with [Claude Code](https://claude.com/claude-code)