### PR TITLE
feat: GET/PUT/DELETE endpoints for individual treatment sessions

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/api/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/exceptions/GlobalExceptionHandler.java
@@ -63,6 +63,12 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.NOT_FOUND, ex.getMessage(), request);
     }
 
+    @ExceptionHandler(TreatmentSessionNotFoundException.class)
+    public ResponseEntity<ApiError> handleTreatmentSessionNotFound(TreatmentSessionNotFoundException ex, HttpServletRequest request) {
+        log.warn("Treatment session not found at {}: {}", request.getRequestURI(), ex.getMessage());
+        return buildError(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
 

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/treatments/TreatmentSessionController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/treatments/TreatmentSessionController.java
@@ -2,7 +2,10 @@ package com.qiromanager.qiromanager_backend.api.treatments;
 
 import com.qiromanager.qiromanager_backend.api.mappers.TreatmentSessionMapper;
 import com.qiromanager.qiromanager_backend.application.treatments.CreateTreatmentSessionUseCase;
+import com.qiromanager.qiromanager_backend.application.treatments.DeleteTreatmentSessionUseCase;
 import com.qiromanager.qiromanager_backend.application.treatments.GetPatientTreatmentSessionsUseCase;
+import com.qiromanager.qiromanager_backend.application.treatments.GetTreatmentSessionByIdUseCase;
+import com.qiromanager.qiromanager_backend.application.treatments.UpdateTreatmentSessionUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -25,6 +28,9 @@ public class TreatmentSessionController {
 
     private final CreateTreatmentSessionUseCase createTreatmentSessionUseCase;
     private final GetPatientTreatmentSessionsUseCase getPatientTreatmentSessionsUseCase;
+    private final GetTreatmentSessionByIdUseCase getTreatmentSessionByIdUseCase;
+    private final UpdateTreatmentSessionUseCase updateTreatmentSessionUseCase;
+    private final DeleteTreatmentSessionUseCase deleteTreatmentSessionUseCase;
     private final TreatmentSessionMapper treatmentSessionMapper;
 
     @Operation(summary = "Log a new treatment session for a patient")
@@ -60,5 +66,55 @@ public class TreatmentSessionController {
         return ResponseEntity.ok(sessions.stream()
                 .map(treatmentSessionMapper::toResponse)
                 .toList());
+    }
+
+    @Operation(summary = "Get a specific treatment session by ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Session found"),
+            @ApiResponse(responseCode = "404", description = "Session not found")
+    })
+    @GetMapping("/{patientId}/sessions/{sessionId}")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    public ResponseEntity<TreatmentSessionResponse> getSessionById(
+            @PathVariable Long patientId,
+            @PathVariable Long sessionId
+    ) {
+        log.info("Request received: Fetch Treatment Session ID: {} for Patient ID: {}", sessionId, patientId);
+        TreatmentSessionResponse response = getTreatmentSessionByIdUseCase.execute(patientId, sessionId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Update a specific treatment session")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Session updated successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request data"),
+            @ApiResponse(responseCode = "404", description = "Session not found")
+    })
+    @PutMapping("/{patientId}/sessions/{sessionId}")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    public ResponseEntity<TreatmentSessionResponse> updateSession(
+            @PathVariable Long patientId,
+            @PathVariable Long sessionId,
+            @Valid @RequestBody UpdateTreatmentSessionRequest request
+    ) {
+        log.info("Request received: Update Treatment Session ID: {} for Patient ID: {}", sessionId, patientId);
+        TreatmentSessionResponse response = updateTreatmentSessionUseCase.execute(patientId, sessionId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Delete a specific treatment session")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Session deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Session not found")
+    })
+    @DeleteMapping("/{patientId}/sessions/{sessionId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteSession(
+            @PathVariable Long patientId,
+            @PathVariable Long sessionId
+    ) {
+        log.info("Request received: Delete Treatment Session ID: {} for Patient ID: {}", sessionId, patientId);
+        deleteTreatmentSessionUseCase.execute(patientId, sessionId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/treatments/UpdateTreatmentSessionRequest.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/treatments/UpdateTreatmentSessionRequest.java
@@ -1,0 +1,17 @@
+package com.qiromanager.qiromanager_backend.api.treatments;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class UpdateTreatmentSessionRequest {
+
+    @NotNull(message = "Session date is required")
+    @PastOrPresent(message = "Session date cannot be in the future")
+    private LocalDateTime sessionDate;
+
+    private String notes;
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/treatments/DeleteTreatmentSessionUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/treatments/DeleteTreatmentSessionUseCase.java
@@ -1,0 +1,27 @@
+package com.qiromanager.qiromanager_backend.application.treatments;
+
+import com.qiromanager.qiromanager_backend.domain.exceptions.TreatmentSessionNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSession;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeleteTreatmentSessionUseCase {
+
+    private final TreatmentSessionRepository treatmentSessionRepository;
+
+    @Transactional
+    public void execute(Long patientId, Long sessionId) {
+        TreatmentSession session = treatmentSessionRepository.findById(sessionId)
+                .filter(s -> s.getPatient().getId().equals(patientId))
+                .orElseThrow(() -> new TreatmentSessionNotFoundException(sessionId));
+
+        treatmentSessionRepository.delete(session.getId());
+        log.info("Treatment session deleted (ID: {})", sessionId);
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/treatments/GetTreatmentSessionByIdUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/treatments/GetTreatmentSessionByIdUseCase.java
@@ -1,0 +1,29 @@
+package com.qiromanager.qiromanager_backend.application.treatments;
+
+import com.qiromanager.qiromanager_backend.api.mappers.TreatmentSessionMapper;
+import com.qiromanager.qiromanager_backend.api.treatments.TreatmentSessionResponse;
+import com.qiromanager.qiromanager_backend.domain.exceptions.TreatmentSessionNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSession;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GetTreatmentSessionByIdUseCase {
+
+    private final TreatmentSessionRepository treatmentSessionRepository;
+    private final TreatmentSessionMapper mapper;
+
+    @Transactional(readOnly = true)
+    public TreatmentSessionResponse execute(Long patientId, Long sessionId) {
+        TreatmentSession session = treatmentSessionRepository.findById(sessionId)
+                .filter(s -> s.getPatient().getId().equals(patientId))
+                .orElseThrow(() -> new TreatmentSessionNotFoundException(sessionId));
+
+        return mapper.toResponse(session);
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/treatments/UpdateTreatmentSessionUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/treatments/UpdateTreatmentSessionUseCase.java
@@ -1,0 +1,33 @@
+package com.qiromanager.qiromanager_backend.application.treatments;
+
+import com.qiromanager.qiromanager_backend.api.mappers.TreatmentSessionMapper;
+import com.qiromanager.qiromanager_backend.api.treatments.TreatmentSessionResponse;
+import com.qiromanager.qiromanager_backend.api.treatments.UpdateTreatmentSessionRequest;
+import com.qiromanager.qiromanager_backend.domain.exceptions.TreatmentSessionNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSession;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateTreatmentSessionUseCase {
+
+    private final TreatmentSessionRepository treatmentSessionRepository;
+    private final TreatmentSessionMapper mapper;
+
+    @Transactional
+    public TreatmentSessionResponse execute(Long patientId, Long sessionId, UpdateTreatmentSessionRequest request) {
+        TreatmentSession session = treatmentSessionRepository.findById(sessionId)
+                .filter(s -> s.getPatient().getId().equals(patientId))
+                .orElseThrow(() -> new TreatmentSessionNotFoundException(sessionId));
+
+        session.update(request.getSessionDate(), request.getNotes());
+        TreatmentSession saved = treatmentSessionRepository.save(session);
+
+        return mapper.toResponse(saved);
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/exceptions/TreatmentSessionNotFoundException.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/exceptions/TreatmentSessionNotFoundException.java
@@ -1,0 +1,8 @@
+package com.qiromanager.qiromanager_backend.domain.exceptions;
+
+public class TreatmentSessionNotFoundException extends RuntimeException {
+
+    public TreatmentSessionNotFoundException(Long id) {
+        super("Treatment session with id " + id + " not found");
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/patient/Patient.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/patient/Patient.java
@@ -93,6 +93,10 @@ public class Patient {
         this.therapists.removeIf(t -> t.equals(therapist));
     }
 
+    public void forceId(Long id) {
+        this.id = id;
+    }
+
     public Set<User> getTherapists() {
         return Collections.unmodifiableSet(therapists);
     }

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/treatment/TreatmentSession.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/treatment/TreatmentSession.java
@@ -57,6 +57,16 @@ public class TreatmentSession {
         return new TreatmentSession(patient, therapist, sessionDate, notes);
     }
 
+    public void forceId(Long id) {
+        this.id = id;
+    }
+
+    public void update(LocalDateTime sessionDate, String notes) {
+        this.sessionDate = sessionDate;
+        this.notes = notes;
+        this.updatedAt = LocalDateTime.now();
+    }
+
     public void updateNotes(String notes) {
         this.notes = notes;
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/treatment/TreatmentSessionRepository.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/treatment/TreatmentSessionRepository.java
@@ -10,4 +10,5 @@ public interface TreatmentSessionRepository {
     List<TreatmentSession> findByPatientId(Long patientId);
     long countSessionsBetween(LocalDateTime start, LocalDateTime end);
     long countTherapistSessionsBetween(Long therapistId, LocalDateTime start, LocalDateTime end);
+    void delete(Long id);
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/treatment/TreatmentSessionRepositoryImpl.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/treatment/TreatmentSessionRepositoryImpl.java
@@ -40,4 +40,9 @@ public class TreatmentSessionRepositoryImpl implements TreatmentSessionRepositor
     public long countTherapistSessionsBetween(Long therapistId, LocalDateTime start, LocalDateTime end) {
         return jpaRepository.countByTherapistIdAndSessionDateBetween(therapistId, start, end);
     }
+
+    @Override
+    public void delete(Long id) {
+        jpaRepository.deleteById(id);
+    }
 }

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/treatments/DeleteTreatmentSessionUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/treatments/DeleteTreatmentSessionUseCaseTest.java
@@ -1,0 +1,77 @@
+package com.qiromanager.qiromanager_backend.application.treatments;
+
+import com.qiromanager.qiromanager_backend.domain.exceptions.TreatmentSessionNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSession;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSessionRepository;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteTreatmentSessionUseCaseTest {
+
+    @Mock
+    private TreatmentSessionRepository treatmentSessionRepository;
+
+    @InjectMocks
+    private DeleteTreatmentSessionUseCase deleteTreatmentSessionUseCase;
+
+    private Patient patient;
+    private User therapist;
+    private TreatmentSession session;
+
+    @BeforeEach
+    void setUp() {
+        therapist = User.create("Jane Doe", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        therapist.forceId(1L);
+
+        patient = Patient.create("John Patient", LocalDate.of(1990, 1, 1), null, null, null, null);
+        patient.forceId(10L);
+
+        session = TreatmentSession.create(patient, therapist, LocalDateTime.now(), "Some notes");
+        session.forceId(100L);
+    }
+
+    @Test
+    void execute_shouldDeleteSession_whenFoundAndBelongsToPatient() {
+        when(treatmentSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+
+        deleteTreatmentSessionUseCase.execute(10L, 100L);
+
+        verify(treatmentSessionRepository).delete(100L);
+    }
+
+    @Test
+    void execute_shouldThrow_whenSessionNotFound() {
+        when(treatmentSessionRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> deleteTreatmentSessionUseCase.execute(10L, 999L))
+                .isInstanceOf(TreatmentSessionNotFoundException.class);
+
+        verify(treatmentSessionRepository, never()).delete(any());
+    }
+
+    @Test
+    void execute_shouldThrow_whenSessionDoesNotBelongToPatient() {
+        when(treatmentSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+
+        // session belongs to patient 10, but we query for patient 99
+        assertThatThrownBy(() -> deleteTreatmentSessionUseCase.execute(99L, 100L))
+                .isInstanceOf(TreatmentSessionNotFoundException.class);
+
+        verify(treatmentSessionRepository, never()).delete(any());
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/treatments/GetTreatmentSessionByIdUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/treatments/GetTreatmentSessionByIdUseCaseTest.java
@@ -1,0 +1,91 @@
+package com.qiromanager.qiromanager_backend.application.treatments;
+
+import com.qiromanager.qiromanager_backend.api.mappers.TreatmentSessionMapper;
+import com.qiromanager.qiromanager_backend.api.treatments.TreatmentSessionResponse;
+import com.qiromanager.qiromanager_backend.domain.exceptions.TreatmentSessionNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSession;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSessionRepository;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetTreatmentSessionByIdUseCaseTest {
+
+    @Mock
+    private TreatmentSessionRepository treatmentSessionRepository;
+
+    @Mock
+    private TreatmentSessionMapper mapper;
+
+    @InjectMocks
+    private GetTreatmentSessionByIdUseCase getTreatmentSessionByIdUseCase;
+
+    private Patient patient;
+    private User therapist;
+    private TreatmentSession session;
+
+    @BeforeEach
+    void setUp() {
+        therapist = User.create("Jane Doe", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        therapist.forceId(1L);
+
+        patient = Patient.create("John Patient", LocalDate.of(1990, 1, 1), null, null, null, null);
+        patient.forceId(10L);
+
+        session = TreatmentSession.create(patient, therapist, LocalDateTime.now(), "Some notes");
+        session.forceId(100L);
+    }
+
+    @Test
+    void execute_shouldReturnSession_whenFoundAndBelongsToPatient() {
+        TreatmentSessionResponse expectedResponse = TreatmentSessionResponse.builder()
+                .id(100L)
+                .patientId(10L)
+                .therapistName("Jane Doe")
+                .sessionDate(session.getSessionDate())
+                .notes("Some notes")
+                .createdAt(session.getCreatedAt())
+                .build();
+
+        when(treatmentSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+        when(mapper.toResponse(session)).thenReturn(expectedResponse);
+
+        TreatmentSessionResponse response = getTreatmentSessionByIdUseCase.execute(10L, 100L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(100L);
+        assertThat(response.getPatientId()).isEqualTo(10L);
+    }
+
+    @Test
+    void execute_shouldThrow_whenSessionNotFound() {
+        when(treatmentSessionRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getTreatmentSessionByIdUseCase.execute(10L, 999L))
+                .isInstanceOf(TreatmentSessionNotFoundException.class);
+    }
+
+    @Test
+    void execute_shouldThrow_whenSessionDoesNotBelongToPatient() {
+        when(treatmentSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+
+        // session belongs to patient 10, but we query for patient 99
+        assertThatThrownBy(() -> getTreatmentSessionByIdUseCase.execute(99L, 100L))
+                .isInstanceOf(TreatmentSessionNotFoundException.class);
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/treatments/UpdateTreatmentSessionUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/treatments/UpdateTreatmentSessionUseCaseTest.java
@@ -1,0 +1,113 @@
+package com.qiromanager.qiromanager_backend.application.treatments;
+
+import com.qiromanager.qiromanager_backend.api.mappers.TreatmentSessionMapper;
+import com.qiromanager.qiromanager_backend.api.treatments.TreatmentSessionResponse;
+import com.qiromanager.qiromanager_backend.api.treatments.UpdateTreatmentSessionRequest;
+import com.qiromanager.qiromanager_backend.domain.exceptions.TreatmentSessionNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSession;
+import com.qiromanager.qiromanager_backend.domain.treatment.TreatmentSessionRepository;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateTreatmentSessionUseCaseTest {
+
+    @Mock
+    private TreatmentSessionRepository treatmentSessionRepository;
+
+    @Mock
+    private TreatmentSessionMapper mapper;
+
+    @InjectMocks
+    private UpdateTreatmentSessionUseCase updateTreatmentSessionUseCase;
+
+    private Patient patient;
+    private User therapist;
+    private TreatmentSession session;
+
+    @BeforeEach
+    void setUp() {
+        therapist = User.create("Jane Doe", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        therapist.forceId(1L);
+
+        patient = Patient.create("John Patient", LocalDate.of(1990, 1, 1), null, null, null, null);
+        patient.forceId(10L);
+
+        session = TreatmentSession.create(patient, therapist, LocalDateTime.now().minusDays(1), "Old notes");
+        session.forceId(100L);
+    }
+
+    @Test
+    void execute_shouldUpdateSession_whenFoundAndBelongsToPatient() {
+        LocalDateTime newDate = LocalDateTime.now();
+        UpdateTreatmentSessionRequest request = new UpdateTreatmentSessionRequest();
+        request.setSessionDate(newDate);
+        request.setNotes("Updated notes");
+
+        TreatmentSessionResponse expectedResponse = TreatmentSessionResponse.builder()
+                .id(100L)
+                .patientId(10L)
+                .therapistName("Jane Doe")
+                .sessionDate(newDate)
+                .notes("Updated notes")
+                .createdAt(session.getCreatedAt())
+                .build();
+
+        when(treatmentSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+        when(treatmentSessionRepository.save(any(TreatmentSession.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(mapper.toResponse(session)).thenReturn(expectedResponse);
+
+        TreatmentSessionResponse response = updateTreatmentSessionUseCase.execute(10L, 100L, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getNotes()).isEqualTo("Updated notes");
+        assertThat(session.getNotes()).isEqualTo("Updated notes");
+        assertThat(session.getSessionDate()).isEqualTo(newDate);
+        verify(treatmentSessionRepository).save(session);
+    }
+
+    @Test
+    void execute_shouldThrow_whenSessionNotFound() {
+        when(treatmentSessionRepository.findById(999L)).thenReturn(Optional.empty());
+
+        UpdateTreatmentSessionRequest request = new UpdateTreatmentSessionRequest();
+        request.setSessionDate(LocalDateTime.now());
+        request.setNotes("Notes");
+
+        assertThatThrownBy(() -> updateTreatmentSessionUseCase.execute(10L, 999L, request))
+                .isInstanceOf(TreatmentSessionNotFoundException.class);
+
+        verify(treatmentSessionRepository, never()).save(any());
+    }
+
+    @Test
+    void execute_shouldThrow_whenSessionDoesNotBelongToPatient() {
+        when(treatmentSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+
+        UpdateTreatmentSessionRequest request = new UpdateTreatmentSessionRequest();
+        request.setSessionDate(LocalDateTime.now());
+        request.setNotes("Notes");
+
+        // session belongs to patient 10, but we query for patient 99
+        assertThatThrownBy(() -> updateTreatmentSessionUseCase.execute(99L, 100L, request))
+                .isInstanceOf(TreatmentSessionNotFoundException.class);
+
+        verify(treatmentSessionRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/patients/{patientId}/sessions/{sessionId}` — fetch a single session (USER, ADMIN)
- Add `PUT /api/v1/patients/{patientId}/sessions/{sessionId}` — update sessionDate + notes (USER, ADMIN)
- Add `DELETE /api/v1/patients/{patientId}/sessions/{sessionId}` — delete a session (ADMIN only)
- New `TreatmentSessionNotFoundException` with 404 handler in `GlobalExceptionHandler`
- All endpoints validate that the session belongs to the given patient
- Full OpenAPI `@Operation`/`@ApiResponse` annotations

## Test plan
- [x] `GetTreatmentSessionByIdUseCaseTest` — happy path, session not found, session belongs to different patient
- [x] `UpdateTreatmentSessionUseCaseTest` — happy path, session not found, session belongs to different patient
- [x] `DeleteTreatmentSessionUseCaseTest` — happy path, session not found, session belongs to different patient
- [x] All 59 existing tests continue to pass (`./mvnw test` → BUILD SUCCESS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)