### PR TITLE
feat: GET/DELETE endpoints for individual clinical records

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/ClinicalRecordController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/clinicalrecords/ClinicalRecordController.java
@@ -1,6 +1,8 @@
 package com.qiromanager.qiromanager_backend.api.clinicalrecords;
 
 import com.qiromanager.qiromanager_backend.application.clinicalrecords.CreateClinicalRecordUseCase;
+import com.qiromanager.qiromanager_backend.application.clinicalrecords.DeleteClinicalRecordUseCase;
+import com.qiromanager.qiromanager_backend.application.clinicalrecords.GetClinicalRecordByIdUseCase;
 import com.qiromanager.qiromanager_backend.application.clinicalrecords.GetPatientClinicalRecordsUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -26,6 +28,8 @@ public class ClinicalRecordController {
 
     private final CreateClinicalRecordUseCase createClinicalRecordUseCase;
     private final GetPatientClinicalRecordsUseCase getPatientClinicalRecordsUseCase;
+    private final GetClinicalRecordByIdUseCase getClinicalRecordByIdUseCase;
+    private final DeleteClinicalRecordUseCase deleteClinicalRecordUseCase;
 
     @Operation(summary = "Create a clinical record for a patient (supports optional file attachment)")
     @ApiResponses({
@@ -63,5 +67,37 @@ public class ClinicalRecordController {
 
         log.debug("Retrieved {} clinical records for Patient ID: {}", records.size(), patientId);
         return ResponseEntity.ok(records);
+    }
+
+    @Operation(summary = "Get a specific clinical record by ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Clinical record found"),
+            @ApiResponse(responseCode = "404", description = "Clinical record not found")
+    })
+    @GetMapping("/{patientId}/clinical-records/{recordId}")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    public ResponseEntity<ClinicalRecordResponse> getClinicalRecordById(
+            @PathVariable Long patientId,
+            @PathVariable Long recordId
+    ) {
+        log.info("Request received: Fetch Clinical Record ID: {} for Patient ID: {}", recordId, patientId);
+        ClinicalRecordResponse response = getClinicalRecordByIdUseCase.execute(patientId, recordId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Delete a specific clinical record")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Clinical record deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Clinical record not found")
+    })
+    @DeleteMapping("/{patientId}/clinical-records/{recordId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteClinicalRecord(
+            @PathVariable Long patientId,
+            @PathVariable Long recordId
+    ) {
+        log.info("Request received: Delete Clinical Record ID: {} for Patient ID: {}", recordId, patientId);
+        deleteClinicalRecordUseCase.execute(patientId, recordId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/api/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/exceptions/GlobalExceptionHandler.java
@@ -63,6 +63,12 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.NOT_FOUND, ex.getMessage(), request);
     }
 
+    @ExceptionHandler(ClinicalRecordNotFoundException.class)
+    public ResponseEntity<ApiError> handleClinicalRecordNotFound(ClinicalRecordNotFoundException ex, HttpServletRequest request) {
+        log.warn("Clinical record not found at {}: {}", request.getRequestURI(), ex.getMessage());
+        return buildError(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
 

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/DeleteClinicalRecordUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/DeleteClinicalRecordUseCase.java
@@ -1,0 +1,27 @@
+package com.qiromanager.qiromanager_backend.application.clinicalrecords;
+
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecord;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecordRepository;
+import com.qiromanager.qiromanager_backend.domain.exceptions.ClinicalRecordNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeleteClinicalRecordUseCase {
+
+    private final ClinicalRecordRepository clinicalRecordRepository;
+
+    @Transactional
+    public void execute(Long patientId, Long recordId) {
+        ClinicalRecord record = clinicalRecordRepository.findById(recordId)
+                .filter(r -> r.getPatient().getId().equals(patientId))
+                .orElseThrow(() -> new ClinicalRecordNotFoundException(recordId));
+
+        clinicalRecordRepository.deleteById(record.getId());
+        log.info("Clinical record deleted (ID: {})", recordId);
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/GetClinicalRecordByIdUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/GetClinicalRecordByIdUseCase.java
@@ -1,0 +1,29 @@
+package com.qiromanager.qiromanager_backend.application.clinicalrecords;
+
+import com.qiromanager.qiromanager_backend.api.clinicalrecords.ClinicalRecordResponse;
+import com.qiromanager.qiromanager_backend.api.mappers.ClinicalRecordMapper;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecord;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecordRepository;
+import com.qiromanager.qiromanager_backend.domain.exceptions.ClinicalRecordNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GetClinicalRecordByIdUseCase {
+
+    private final ClinicalRecordRepository clinicalRecordRepository;
+    private final ClinicalRecordMapper mapper;
+
+    @Transactional(readOnly = true)
+    public ClinicalRecordResponse execute(Long patientId, Long recordId) {
+        ClinicalRecord record = clinicalRecordRepository.findById(recordId)
+                .filter(r -> r.getPatient().getId().equals(patientId))
+                .orElseThrow(() -> new ClinicalRecordNotFoundException(recordId));
+
+        return mapper.toResponse(record);
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/clinicalhistory/ClinicalRecord.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/clinicalhistory/ClinicalRecord.java
@@ -69,6 +69,10 @@ public class ClinicalRecord {
         return new ClinicalRecord(patient, performedBy, type, content);
     }
 
+    public void forceId(Long id) {
+        this.id = id;
+    }
+
     public void update(String content, RecordType type) {
         boolean changed = false;
 

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/exceptions/ClinicalRecordNotFoundException.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/exceptions/ClinicalRecordNotFoundException.java
@@ -1,0 +1,7 @@
+package com.qiromanager.qiromanager_backend.domain.exceptions;
+
+public class ClinicalRecordNotFoundException extends RuntimeException {
+    public ClinicalRecordNotFoundException(Long id) {
+        super("Clinical record with id " + id + " not found");
+    }
+}

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/patient/Patient.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/patient/Patient.java
@@ -104,6 +104,10 @@ public class Patient {
         this.therapists.removeIf(t -> t.equals(therapist));
     }
 
+    public void forceId(Long id) {
+        this.id = id;
+    }
+
     public Set<User> getTherapists() {
         return Collections.unmodifiableSet(therapists);
     }

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/DeleteClinicalRecordUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/DeleteClinicalRecordUseCaseTest.java
@@ -1,0 +1,77 @@
+package com.qiromanager.qiromanager_backend.application.clinicalrecords;
+
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecord;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecordRepository;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.RecordType;
+import com.qiromanager.qiromanager_backend.domain.exceptions.ClinicalRecordNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteClinicalRecordUseCaseTest {
+
+    @Mock
+    private ClinicalRecordRepository clinicalRecordRepository;
+
+    @InjectMocks
+    private DeleteClinicalRecordUseCase deleteClinicalRecordUseCase;
+
+    private Patient patient;
+    private User therapist;
+    private ClinicalRecord record;
+
+    @BeforeEach
+    void setUp() {
+        therapist = User.create("Jane Doe", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        therapist.forceId(1L);
+
+        patient = Patient.create("John Patient", LocalDate.of(1990, 1, 1), null, null, null, null);
+        patient.forceId(10L);
+
+        record = ClinicalRecord.create(patient, therapist, RecordType.ANAMNESIS, "Record content");
+        record.forceId(50L);
+    }
+
+    @Test
+    void execute_shouldDeleteRecord_whenFoundAndBelongsToPatient() {
+        when(clinicalRecordRepository.findById(50L)).thenReturn(Optional.of(record));
+
+        deleteClinicalRecordUseCase.execute(10L, 50L);
+
+        verify(clinicalRecordRepository).deleteById(50L);
+    }
+
+    @Test
+    void execute_shouldThrow_whenRecordNotFound() {
+        when(clinicalRecordRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> deleteClinicalRecordUseCase.execute(10L, 999L))
+                .isInstanceOf(ClinicalRecordNotFoundException.class);
+
+        verify(clinicalRecordRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void execute_shouldThrow_whenRecordDoesNotBelongToPatient() {
+        when(clinicalRecordRepository.findById(50L)).thenReturn(Optional.of(record));
+
+        // record belongs to patient 10, but we query for patient 99
+        assertThatThrownBy(() -> deleteClinicalRecordUseCase.execute(99L, 50L))
+                .isInstanceOf(ClinicalRecordNotFoundException.class);
+
+        verify(clinicalRecordRepository, never()).deleteById(any());
+    }
+}

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/GetClinicalRecordByIdUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/clinicalrecords/GetClinicalRecordByIdUseCaseTest.java
@@ -1,0 +1,93 @@
+package com.qiromanager.qiromanager_backend.application.clinicalrecords;
+
+import com.qiromanager.qiromanager_backend.api.clinicalrecords.ClinicalRecordResponse;
+import com.qiromanager.qiromanager_backend.api.mappers.ClinicalRecordMapper;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecord;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.ClinicalRecordRepository;
+import com.qiromanager.qiromanager_backend.domain.clinicalhistory.RecordType;
+import com.qiromanager.qiromanager_backend.domain.exceptions.ClinicalRecordNotFoundException;
+import com.qiromanager.qiromanager_backend.domain.patient.Patient;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetClinicalRecordByIdUseCaseTest {
+
+    @Mock
+    private ClinicalRecordRepository clinicalRecordRepository;
+
+    @Mock
+    private ClinicalRecordMapper mapper;
+
+    @InjectMocks
+    private GetClinicalRecordByIdUseCase getClinicalRecordByIdUseCase;
+
+    private Patient patient;
+    private User therapist;
+    private ClinicalRecord record;
+
+    @BeforeEach
+    void setUp() {
+        therapist = User.create("Jane Doe", "janedoe", "jane@clinic.com", "pass", Role.USER);
+        therapist.forceId(1L);
+
+        patient = Patient.create("John Patient", LocalDate.of(1990, 1, 1), null, null, null, null);
+        patient.forceId(10L);
+
+        record = ClinicalRecord.create(patient, therapist, RecordType.EVOLUTION, "Initial evaluation content");
+        record.forceId(50L);
+    }
+
+    @Test
+    void execute_shouldReturnRecord_whenFoundAndBelongsToPatient() {
+        ClinicalRecordResponse expectedResponse = ClinicalRecordResponse.builder()
+                .id(50L)
+                .patientId(10L)
+                .performedByName("Jane Doe")
+                .type(RecordType.EVOLUTION)
+                .content("Initial evaluation content")
+                .attachments(Collections.emptyList())
+                .createdAt(record.getCreatedAt())
+                .build();
+
+        when(clinicalRecordRepository.findById(50L)).thenReturn(Optional.of(record));
+        when(mapper.toResponse(record)).thenReturn(expectedResponse);
+
+        ClinicalRecordResponse response = getClinicalRecordByIdUseCase.execute(10L, 50L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(50L);
+        assertThat(response.getPatientId()).isEqualTo(10L);
+    }
+
+    @Test
+    void execute_shouldThrow_whenRecordNotFound() {
+        when(clinicalRecordRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getClinicalRecordByIdUseCase.execute(10L, 999L))
+                .isInstanceOf(ClinicalRecordNotFoundException.class);
+    }
+
+    @Test
+    void execute_shouldThrow_whenRecordDoesNotBelongToPatient() {
+        when(clinicalRecordRepository.findById(50L)).thenReturn(Optional.of(record));
+
+        // record belongs to patient 10, but we query for patient 99
+        assertThatThrownBy(() -> getClinicalRecordByIdUseCase.execute(99L, 50L))
+                .isInstanceOf(ClinicalRecordNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/patients/{patientId}/clinical-records/{recordId}` — fetch a single record (USER, ADMIN)
- Add `DELETE /api/v1/patients/{patientId}/clinical-records/{recordId}` — delete a record (ADMIN only)
- New `ClinicalRecordNotFoundException` with 404 handler in `GlobalExceptionHandler`
- Both endpoints validate that the record belongs to the given patient
- Full OpenAPI `@Operation`/`@ApiResponse` annotations

## Test plan
- [x] `GetClinicalRecordByIdUseCaseTest` — happy path, record not found, record belongs to different patient
- [x] `DeleteClinicalRecordUseCaseTest` — happy path, record not found, record belongs to different patient
- [x] All 56 existing tests continue to pass (`./mvnw test` → BUILD SUCCESS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)