### PR TITLE
feat: optional ?role= filter on GET /api/v1/users

### DIFF
--- a/src/main/java/com/qiromanager/qiromanager_backend/api/users/UserController.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/api/users/UserController.java
@@ -2,6 +2,7 @@ package com.qiromanager.qiromanager_backend.api.users;
 
 import com.qiromanager.qiromanager_backend.api.mappers.UserMapper;
 import com.qiromanager.qiromanager_backend.application.users.*;
+import com.qiromanager.qiromanager_backend.domain.user.Role;
 import com.qiromanager.qiromanager_backend.domain.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -30,14 +31,22 @@ public class UserController {
     private final GetAuthenticatedUserUseCase getAuthenticatedUserUseCase;
     private final UpdateUserProfileUseCase updateUserProfileUseCase;
 
-    @Operation(summary = "List all users (ADMIN only)")
-    @ApiResponse(responseCode = "200", description = "List of all users")
+    @Operation(summary = "List all users, optionally filtered by role (ADMIN only)")
+    @ApiResponse(responseCode = "200", description = "List of users")
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<List<UserResponse>> getAllUsers() {
-        log.info("Request received: List all users (ADMIN action)");
+    public ResponseEntity<List<UserResponse>> getAllUsers(
+            @RequestParam(required = false) String role
+    ) {
+        Role parsedRole = null;
+        if (role != null && !role.isBlank()) {
+            parsedRole = Role.valueOf(role.toUpperCase());
+            log.info("Request received: List users filtered by role={} (ADMIN action)", parsedRole);
+        } else {
+            log.info("Request received: List all users (ADMIN action)");
+        }
 
-        List<User> users = listUsersUseCase.execute();
+        List<User> users = listUsersUseCase.execute(parsedRole);
 
         log.debug("Returning {} users", users.size());
         return ResponseEntity.ok(users.stream()

--- a/src/main/java/com/qiromanager/qiromanager_backend/application/users/ListUsersUseCase.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/application/users/ListUsersUseCase.java
@@ -1,5 +1,6 @@
 package com.qiromanager.qiromanager_backend.application.users;
 
+import com.qiromanager.qiromanager_backend.domain.user.Role;
 import com.qiromanager.qiromanager_backend.domain.user.User;
 import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,10 @@ public class ListUsersUseCase {
 
     private final UserRepository userRepository;
 
-    public List<User> execute() {
+    public List<User> execute(Role role) {
+        if (role != null) {
+            return userRepository.findByRole(role);
+        }
         return userRepository.findAll();
     }
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/domain/user/UserRepository.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/domain/user/UserRepository.java
@@ -18,5 +18,7 @@ public interface UserRepository {
     User save(User user);
 
     List<User> findAll();
+
+    List<User> findByRole(Role role);
 }
 

--- a/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/user/UserRepositoryImpl.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/user/UserRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.qiromanager.qiromanager_backend.infrastructure.user;
 
+import com.qiromanager.qiromanager_backend.domain.user.Role;
 import com.qiromanager.qiromanager_backend.domain.user.User;
 import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
 import com.qiromanager.qiromanager_backend.infrastructure.user.jpa.JpaUserRepository;
@@ -50,5 +51,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public List<User> findAll() {
         return jpaRepository.findAll();
+    }
+
+    @Override
+    public List<User> findByRole(Role role) {
+        return jpaRepository.findByRole(role);
     }
 }

--- a/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/user/jpa/JpaUserRepository.java
+++ b/src/main/java/com/qiromanager/qiromanager_backend/infrastructure/user/jpa/JpaUserRepository.java
@@ -1,8 +1,10 @@
 package com.qiromanager.qiromanager_backend.infrastructure.user.jpa;
 
+import com.qiromanager.qiromanager_backend.domain.user.Role;
 import com.qiromanager.qiromanager_backend.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JpaUserRepository extends JpaRepository<User, Long> {
@@ -14,4 +16,6 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
     boolean existsByEmail(String email);
+
+    List<User> findByRole(Role role);
 }

--- a/src/test/java/com/qiromanager/qiromanager_backend/api/users/UserControllerIT.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/api/users/UserControllerIT.java
@@ -42,7 +42,7 @@ class UserControllerIT {
     void getAllUsers_ShouldReturn200_WhenUserIsAdmin() throws Exception {
         User user = User.create("Test User", "test", "test@test.com", "pass", Role.USER);
         user.forceId(1L);
-        when(listUsersUseCase.execute()).thenReturn(List.of(user));
+        when(listUsersUseCase.execute(null)).thenReturn(List.of(user));
 
         mockMvc.perform(get("/api/v1/users"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/qiromanager/qiromanager_backend/application/users/ListUsersUseCaseTest.java
+++ b/src/test/java/com/qiromanager/qiromanager_backend/application/users/ListUsersUseCaseTest.java
@@ -1,0 +1,67 @@
+package com.qiromanager.qiromanager_backend.application.users;
+
+import com.qiromanager.qiromanager_backend.domain.user.Role;
+import com.qiromanager.qiromanager_backend.domain.user.User;
+import com.qiromanager.qiromanager_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ListUsersUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ListUsersUseCase listUsersUseCase;
+
+    @Test
+    void execute_shouldReturnAllUsers_whenRoleIsNull() {
+        User admin = User.create("Admin User", "admin", "admin@clinic.com", "pass", Role.ADMIN);
+        User therapist = User.create("Therapist", "therapist", "therapist@clinic.com", "pass", Role.USER);
+
+        when(userRepository.findAll()).thenReturn(List.of(admin, therapist));
+
+        List<User> result = listUsersUseCase.execute(null);
+
+        assertThat(result).hasSize(2);
+        verify(userRepository).findAll();
+        verify(userRepository, never()).findByRole(any());
+    }
+
+    @Test
+    void execute_shouldReturnFilteredUsers_whenRoleIsUser() {
+        User therapist = User.create("Therapist", "therapist", "therapist@clinic.com", "pass", Role.USER);
+
+        when(userRepository.findByRole(Role.USER)).thenReturn(List.of(therapist));
+
+        List<User> result = listUsersUseCase.execute(Role.USER);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRole()).isEqualTo(Role.USER);
+        verify(userRepository).findByRole(Role.USER);
+        verify(userRepository, never()).findAll();
+    }
+
+    @Test
+    void execute_shouldReturnFilteredUsers_whenRoleIsAdmin() {
+        User admin = User.create("Admin User", "admin", "admin@clinic.com", "pass", Role.ADMIN);
+
+        when(userRepository.findByRole(Role.ADMIN)).thenReturn(List.of(admin));
+
+        List<User> result = listUsersUseCase.execute(Role.ADMIN);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRole()).isEqualTo(Role.ADMIN);
+        verify(userRepository).findByRole(Role.ADMIN);
+        verify(userRepository, never()).findAll();
+    }
+}


### PR DESCRIPTION
## Summary
- Add optional `?role=USER` or `?role=ADMIN` query param to `GET /api/v1/users`
- When `role` is provided, returns only users with that role; omit param for all users
- Updated `ListUsersUseCase.execute(Role)` to accept a nullable `Role` parameter
- Spring Data derived method `findByRole(Role)` added to `JpaUserRepository`

## Test plan
- [x] `ListUsersUseCaseTest` — no filter returns all, `?role=USER` filters to USER, `?role=ADMIN` filters to ADMIN
- [x] Updated `UserControllerIT` to pass `null` in existing mock stub (no behaviour change)
- [x] All 53 existing tests continue to pass (`./mvnw test` → BUILD SUCCESS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)